### PR TITLE
fix: make agents listing publicly accessible

### DIFF
--- a/backend/agents_test.go
+++ b/backend/agents_test.go
@@ -28,6 +28,23 @@ func TestListAgents_Empty(t *testing.T) {
 	}
 }
 
+func TestListAgents_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	// Anonymous users should be able to list agents without a token.
+	rr := doRequest(t, router, http.MethodGet, "/api/ui/agents/", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unauthenticated request, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var agents []Agent
+	if err := json.Unmarshal(rr.Body.Bytes(), &agents); err != nil {
+		t.Fatalf("failed to decode agents: %v", err)
+	}
+}
+
 func TestCreateAgent(t *testing.T) {
 	t.Parallel()
 	app := setupTestApp(t)
@@ -139,6 +156,27 @@ func TestGetAgent(t *testing.T) {
 	rr := doRequest(t, router, http.MethodGet, "/api/ui/agents/"+agentID, nil, token)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var a Agent
+	json.Unmarshal(rr.Body.Bytes(), &a)
+	if a.ID != agentID {
+		t.Errorf("expected agent ID %q, got %q", agentID, a.ID)
+	}
+}
+
+func TestGetAgent_Unauthenticated(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	handlerID, _ := createTestUser(t, app, "AGENT_HANDLER")
+	agentID, _ := createTestAgent(t, app, handlerID)
+
+	// Anonymous users should also be able to fetch a single agent.
+	rr := doRequest(t, router, http.MethodGet, "/api/ui/agents/"+agentID, nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for unauthenticated request, got %d: %s", rr.Code, rr.Body.String())
 	}
 
 	var a Agent

--- a/backend/router.go
+++ b/backend/router.go
@@ -74,14 +74,15 @@ func NewRouter(app *App) *chi.Mux {
 		r.Post("/reset-password", app.ResetPasswordHandler)
 	})
 
+	// Public agent browsing routes (no auth required)
+	r.Route("/api/ui/agents", func(r chi.Router) {
+		r.Get("/", app.ListAgentsHandler)
+		r.Get("/{id}", app.GetAgentHandler)
+	})
+
 	// JWT-protected UI routes
 	r.Route("/api/ui", func(r chi.Router) {
 		r.Use(app.JWTAuth)
-
-		r.Route("/agents", func(r chi.Router) {
-			r.Get("/", app.ListAgentsHandler)
-			r.Get("/{id}", app.GetAgentHandler)
-		})
 
 		r.Route("/handlers", func(r chi.Router) {
 			r.Post("/agents", app.CreateAgentHandler)


### PR DESCRIPTION
## Summary
- Moves `GET /api/ui/agents` and `GET /api/ui/agents/{id}` outside the JWT middleware group so anonymous users can browse agents on the homepage
- Fixes #4 (Failed to load agents)
- All write operations (create agent, hire, milestones) remain JWT-protected

## What changed
In `backend/router.go`, the two read-only agent routes are now registered as public routes before the JWT-protected `/api/ui` group. The JWT-protected group retains all mutation routes (`/handlers`, `/jobs`, etc.).

## Test plan
- [ ] Visit homepage without logging in — agents should load successfully
- [ ] Verify authenticated routes still require JWT (create agent, hire agent, etc.)
- [ ] Two new tests added: `TestListAgents_Unauthenticated` and `TestGetAgent_Unauthenticated` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)