### PR TITLE
feat: implement new hiring flow — job brief first, then assign agent

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -70,6 +70,10 @@ type HireRequest struct {
 	Milestones   []MilestoneInput `json:"milestones"`
 }
 
+type AssignAgentRequest struct {
+	AgentID string `json:"agent_id"`
+}
+
 type SubmitProofRequest struct {
 	ProofOfWorkURL   string `json:"proof_of_work_url"`
 	ProofOfWorkNotes string `json:"proof_of_work_notes"`
@@ -266,6 +270,84 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(job)
+}
+
+// AssignAgentHandler assigns an agent to an existing unassigned job.
+// Requires email verification (because this initiates the agent relationship).
+func (app *App) AssignAgentHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "assign_agent")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "EMPLOYER" {
+		log.Warn("authz failure: assign agent requires EMPLOYER role", "role", role)
+		writeError(w, http.StatusForbidden, "only EMPLOYER role can assign agents")
+		return
+	}
+
+	employerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "id")
+
+	var req AssignAgentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.AgentID == "" {
+		writeError(w, http.StatusBadRequest, "agent_id is required")
+		return
+	}
+
+	// Email verification required to assign an agent
+	var emailVerifiedAt sql.NullTime
+	err := app.DB.QueryRow("SELECT email_verified_at FROM users WHERE id = ?", employerID).Scan(&emailVerifiedAt)
+	if err != nil {
+		log.Error("assign agent: database error checking email verification", "employer_id", employerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	if !emailVerifiedAt.Valid {
+		log.Warn("assign agent blocked: employer email not verified", "employer_id", employerID)
+		writeError(w, http.StatusForbidden, "Please verify your email before assigning an agent")
+		return
+	}
+
+	// Verify agent exists and is active
+	var agentExists int
+	err = app.DB.QueryRow("SELECT COUNT(*) FROM agents WHERE id = ? AND is_active = 1", req.AgentID).Scan(&agentExists)
+	if err != nil || agentExists == 0 {
+		writeError(w, http.StatusNotFound, "agent not found or inactive")
+		return
+	}
+
+	// Only allow assigning to jobs owned by this employer that have no agent yet
+	result, err := app.DB.Exec(
+		`UPDATE jobs SET agent_id = ?, status = 'PENDING_ACCEPTANCE', updated_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND employer_id = ? AND (agent_id = '' OR agent_id IS NULL)`,
+		req.AgentID, jobID, employerID,
+	)
+	if err != nil {
+		log.Error("assign agent: database error", "job_id", jobID, "employer_id", employerID, "agent_id", req.AgentID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to assign agent")
+		return
+	}
+
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "job not found, not owned by you, or already has an agent assigned")
+		return
+	}
+
+	log.Info("agent assigned to job", "job_id", jobID, "employer_id", employerID, "agent_id", req.AgentID)
+
+	j, err := app.getJobDetail(jobID)
+	if err != nil {
+		log.Error("assign agent: failed to retrieve after update", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve job")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(j)
 }
 
 func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {

--- a/backend/router.go
+++ b/backend/router.go
@@ -66,7 +66,7 @@ func NewRouter(app *App) *chi.Mux {
 
 		// Static files
 		spa := spaHandler{
-			staticPath: "./static", 
+			staticPath: "./static",
 			indexPath:  "index.html",
 		}
 		r.Handle("/*", spa)
@@ -106,6 +106,7 @@ func NewRouter(app *App) *chi.Mux {
 				r.Post("/hire", app.HireAgentHandler)
 				r.Get("/", app.ListJobsHandler)
 				r.Get("/{id}", app.GetJobHandler)
+				r.Post("/{id}/assign", app.AssignAgentHandler)
 				r.Post("/{job_id}/milestones/{milestone_id}/approve", app.ApproveMilestoneHandler)
 				r.Post("/{job_id}/sow", app.CreateOrUpdateSOW)
 				r.Get("/{job_id}/sow", app.GetSOW)

--- a/frontend/src/routes/agents/[id]/+page.svelte
+++ b/frontend/src/routes/agents/[id]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import { isAuthenticated, auth } from '$lib/stores/auth';
+	import { isAuthenticated, auth, apiFetch } from '$lib/stores/auth';
 
 	interface Agent {
 		id: string;
@@ -14,9 +14,26 @@
 		updated_at: string;
 	}
 
+	interface Job {
+		id: string;
+		agent_id: string;
+		title: string;
+		description: string;
+		status: string;
+		total_payout: number;
+	}
+
 	let agent: Agent | null = $state(null);
 	let loading = $state(true);
 	let error = $state('');
+
+	// Hire panel state
+	let hireOpen = $state(false);
+	let unassignedJobs: Job[] = $state([]);
+	let jobsLoading = $state(false);
+	let assigningJobId = $state('');
+	let assignError = $state('');
+	let assignSuccess = $state('');
 
 	const agentId = $derived($page.params.id);
 
@@ -34,6 +51,54 @@
 			loading = false;
 		}
 	});
+
+	async function openHirePanel() {
+		hireOpen = true;
+		assignError = '';
+		assignSuccess = '';
+		if ($isAuthenticated && $auth?.role === 'EMPLOYER') {
+			jobsLoading = true;
+			try {
+				const res = await apiFetch('/api/ui/jobs');
+				if (!res.ok) throw new Error('Failed to load jobs');
+				const all: Job[] = await res.json();
+				unassignedJobs = all.filter((j) => !j.agent_id || j.agent_id === '');
+			} catch {
+				unassignedJobs = [];
+			} finally {
+				jobsLoading = false;
+			}
+		}
+	}
+
+	function closeHirePanel() {
+		hireOpen = false;
+		assignError = '';
+		assignSuccess = '';
+	}
+
+	async function sendOffer(jobId: string) {
+		assigningJobId = jobId;
+		assignError = '';
+		assignSuccess = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/assign`, {
+				method: 'POST',
+				body: JSON.stringify({ agent_id: agentId })
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to send offer' }));
+				throw new Error(err.error || 'Failed to send offer');
+			}
+			assignSuccess = 'Offer sent! The agent will review your job.';
+			// Remove the job from unassigned list
+			unassignedJobs = unassignedJobs.filter((j) => j.id !== jobId);
+		} catch (e: unknown) {
+			assignError = e instanceof Error ? e.message : 'Failed to send offer';
+		} finally {
+			assigningJobId = '';
+		}
+	}
 </script>
 
 <svelte:head>
@@ -57,7 +122,7 @@
 					<h1 style="margin: 0 0 0.25rem; font-size: 1.75rem;">{agent.name}</h1>
 				</div>
 				{#if $isAuthenticated && $auth?.role === 'EMPLOYER'}
-					<a href="/hire/{agent.id}" class="btn btn-primary">Hire this agent</a>
+					<button class="btn btn-primary" onclick={openHirePanel}>Hire this agent</button>
 				{:else if !$isAuthenticated}
 					<a href="/auth/signup" class="btn btn-primary">Sign up to hire</a>
 				{/if}
@@ -67,10 +132,70 @@
 				<p style="color: #444; line-height: 1.6; margin-bottom: 1rem;">{agent.description}</p>
 			{/if}
 
-
 			<div style="display: flex; gap: 2rem; flex-wrap: wrap; padding-top: 1rem; border-top: 1px solid #f0f0f0; font-size: 0.9rem; color: #666;">
 				<span>Handler</span>
 			</div>
 		</div>
+
+		<!-- Hire panel -->
+		{#if hireOpen}
+			<div style="position: fixed; inset: 0; background: rgba(0,0,0,0.4); z-index: 100; display: flex; align-items: center; justify-content: center; padding: 1rem;">
+				<div style="background: #fff; border-radius: 10px; padding: 2rem; max-width: 560px; width: 100%; max-height: 80vh; overflow-y: auto; box-shadow: 0 8px 40px rgba(0,0,0,0.18);">
+					<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.25rem;">
+						<h2 style="margin: 0; font-size: 1.2rem;">Hire {agent.name}</h2>
+						<button onclick={closeHirePanel} style="background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #888; line-height: 1;" title="Close">×</button>
+					</div>
+
+					{#if assignError}
+						<div class="alert alert-error" style="margin-bottom: 1rem;">{assignError}</div>
+					{/if}
+					{#if assignSuccess}
+						<div class="alert alert-success" style="margin-bottom: 1rem;">{assignSuccess}</div>
+					{/if}
+
+					{#if jobsLoading}
+						<p style="color: #888; text-align: center; padding: 1rem 0;">Loading your job briefs...</p>
+					{:else if unassignedJobs.length > 0}
+						<p style="color: #555; margin-bottom: 1rem; font-size: 0.95rem;">
+							Select one of your existing job briefs to send as an offer to this agent:
+						</p>
+						<div style="display: flex; flex-direction: column; gap: 0.75rem; margin-bottom: 1.25rem;">
+							{#each unassignedJobs as job}
+								<div style="border: 1px solid #e0e0e0; border-radius: 8px; padding: 0.9rem 1rem; display: flex; justify-content: space-between; align-items: center; gap: 1rem;">
+									<div>
+										<strong style="font-size: 0.95rem;">{job.title}</strong>
+										{#if job.description}
+											<div style="font-size: 0.82rem; color: #888; margin-top: 0.15rem;">
+												{job.description.length > 60 ? job.description.slice(0, 60) + '…' : job.description}
+											</div>
+										{/if}
+										<div style="font-size: 0.82rem; color: #666; margin-top: 0.2rem;">${job.total_payout.toFixed(2)}</div>
+									</div>
+									<button
+										class="btn btn-primary"
+										style="font-size: 0.85rem; padding: 0.35rem 0.9rem; white-space: nowrap;"
+										disabled={assigningJobId === job.id}
+										onclick={() => sendOffer(job.id)}
+									>
+										{assigningJobId === job.id ? 'Sending…' : 'Send Offer'}
+									</button>
+								</div>
+							{/each}
+						</div>
+						<div style="border-top: 1px solid #f0f0f0; padding-top: 1rem; text-align: center;">
+							<p style="color: #888; font-size: 0.9rem; margin-bottom: 0.75rem;">Or create a new job brief for this agent:</p>
+							<a href="/jobs/new?return_to=/agents/{agentId}" class="btn btn-secondary">Enter a Job Brief</a>
+						</div>
+					{:else}
+						<p style="color: #555; margin-bottom: 1.25rem; font-size: 0.95rem;">
+							You don't have any unassigned job briefs yet. Create one now to send an offer to this agent.
+						</p>
+						<div style="text-align: center;">
+							<a href="/jobs/new?return_to=/agents/{agentId}" class="btn btn-primary">Enter a Job Brief</a>
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
 	{/if}
 </div>

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -42,13 +42,18 @@
 			DELIVERED: 'badge-delivered',
 			COMPLETED: 'badge-completed',
 			PENDING: 'badge-pending',
+			PENDING_ACCEPTANCE: 'badge-pending',
 			CANCELLED: 'badge-cancelled'
 		};
 		return map[status] ?? 'badge-pending';
 	}
 
 	function statusLabel(status: string): string {
-		return status.replace('_', ' ').toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
+		return status.replace(/_/g, ' ').toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
+	}
+
+	function isUnassigned(job: Job): boolean {
+		return !job.agent_id || job.agent_id === '';
 	}
 
 	onMount(async () => {
@@ -80,9 +85,9 @@
 	<div class="page-header" style="display: flex; justify-content: space-between; align-items: flex-start; flex-wrap: wrap; gap: 1rem;">
 		<div>
 			<h1>Employer Dashboard</h1>
-			<p>Manage your posted jobs and track agent progress.</p>
+			<p>Manage your job briefs and track agent progress.</p>
 		</div>
-		<a href="/" class="btn btn-primary">Browse agents</a>
+		<a href="/jobs/new" class="btn btn-primary">Enter a Job Brief</a>
 	</div>
 
 	{#if loading}
@@ -91,8 +96,9 @@
 		<div class="alert alert-error">{error}</div>
 	{:else if jobs.length === 0}
 		<div class="card" style="text-align: center; padding: 3rem; color: #888;">
-			<p>No jobs yet.</p>
-			<a href="/" class="btn btn-primary" style="margin-top: 0.75rem;">Find an agent to hire</a>
+			<p>No job briefs yet.</p>
+			<p style="font-size: 0.9rem; margin-top: 0.5rem;">Create a job brief first, then assign it to an agent.</p>
+			<a href="/jobs/new" class="btn btn-primary" style="margin-top: 0.75rem;">Enter a Job Brief</a>
 		</div>
 	{:else}
 		<div style="background: #fff; border: 1px solid #e0e0e0; border-radius: 8px; overflow: hidden;">
@@ -104,6 +110,7 @@
 						<th>Status</th>
 						<th>Payout</th>
 						<th>Milestones</th>
+						<th></th>
 					</tr>
 				</thead>
 				<tbody>
@@ -118,7 +125,11 @@
 								{/if}
 							</td>
 							<td>
-								<a href="/agents/{job.agent_id}">Agent #{job.agent_id.slice(0, 8)}</a>
+								{#if isUnassigned(job)}
+									<span style="color: #aaa; font-style: italic; font-size: 0.9rem;">Not assigned</span>
+								{:else}
+									<a href="/agents/{job.agent_id}">Agent #{job.agent_id.slice(0, 8)}</a>
+								{/if}
 							</td>
 							<td>
 								<span class="badge {statusBadge(job.status)}">{statusLabel(job.status)}</span>
@@ -129,6 +140,13 @@
 									{job.milestones.filter(m => m.status === 'COMPLETED').length}/{job.milestones.length} done
 								{:else}
 									—
+								{/if}
+							</td>
+							<td>
+								{#if isUnassigned(job)}
+									<a href="/" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap;">
+										Submit to Agent
+									</a>
 								{/if}
 							</td>
 						</tr>

--- a/frontend/src/routes/jobs/new/+page.svelte
+++ b/frontend/src/routes/jobs/new/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/stores';
+
+	interface Milestone {
+		title: string;
+		payout: number;
+		criteria: string[];
+	}
+
+	let title = $state('');
+	let description = $state('');
+	let payout = $state(0);
+	let timeline = $state('');
+	let milestones: Milestone[] = $state([{ title: '', payout: 0, criteria: [''] }]);
+
+	let submitting = $state(false);
+	let error = $state('');
+
+	// Where to go back after saving (agent_id passed as query param to trigger assign flow)
+	const returnTo = $derived($page.url.searchParams.get('return_to') ?? '/dashboard/employer');
+
+	onMount(() => {
+		if (!$isAuthenticated) {
+			goto('/auth/login');
+			return;
+		}
+		if ($auth?.role !== 'EMPLOYER') {
+			goto('/dashboard/employer');
+		}
+	});
+
+	function addMilestone() {
+		milestones = [...milestones, { title: '', payout: 0, criteria: [''] }];
+	}
+
+	function removeMilestone(i: number) {
+		milestones = milestones.filter((_, idx) => idx !== i);
+	}
+
+	function addCriteria(milestoneIdx: number) {
+		milestones = milestones.map((m, i) =>
+			i === milestoneIdx ? { ...m, criteria: [...m.criteria, ''] } : m
+		);
+	}
+
+	function removeCriteria(milestoneIdx: number, criteriaIdx: number) {
+		milestones = milestones.map((m, i) =>
+			i === milestoneIdx
+				? { ...m, criteria: m.criteria.filter((_, ci) => ci !== criteriaIdx) }
+				: m
+		);
+	}
+
+	function updateCriteria(milestoneIdx: number, criteriaIdx: number, value: string) {
+		milestones = milestones.map((m, i) =>
+			i === milestoneIdx
+				? { ...m, criteria: m.criteria.map((c, ci) => (ci === criteriaIdx ? value : c)) }
+				: m
+		);
+	}
+
+	async function handleSubmit(e: SubmitEvent) {
+		e.preventDefault();
+		error = '';
+		submitting = true;
+		try {
+			const payload = {
+				agent_id: '',
+				title,
+				description,
+				total_payout: Math.round(Number(payout)),
+				timeline_days: Math.round(Number(timeline)) || 0,
+				milestones: milestones.map((m) => ({
+					title: m.title,
+					amount: Math.round(Number(m.payout || 0)),
+					criteria: m.criteria.filter((c) => c.trim())
+				}))
+			};
+			const res = await apiFetch('/api/ui/jobs/hire', {
+				method: 'POST',
+				body: JSON.stringify(payload)
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to create job' }));
+				throw new Error(err.error || 'Failed to create job');
+			}
+			goto(returnTo);
+		} catch (e: unknown) {
+			error = e instanceof Error ? e.message : 'Failed to submit job';
+		} finally {
+			submitting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>Enter a Job Brief — AgentMarket</title>
+</svelte:head>
+
+<div class="container page">
+	<div style="margin-bottom: 1rem;">
+		<a href={returnTo} style="color: #888; font-size: 0.9rem;">← Back</a>
+	</div>
+
+	<div class="page-header">
+		<h1>Enter a Job Brief</h1>
+		<p>Describe the work, set milestones, and define success criteria. You can assign an agent later.</p>
+	</div>
+
+	{#if error}
+		<div class="alert alert-error">{error}</div>
+	{/if}
+
+	<form onsubmit={handleSubmit}>
+		<div class="card" style="margin-bottom: 1.5rem;">
+			<h2 style="margin: 0 0 1rem; font-size: 1.1rem;">Job details</h2>
+			<div class="form-group">
+				<label for="title">Title</label>
+				<input id="title" type="text" bind:value={title} required placeholder="e.g. Build a landing page, Research competitors" />
+			</div>
+			<div class="form-group">
+				<label for="description">Description</label>
+				<textarea id="description" bind:value={description} required placeholder="Describe the task in detail. What do you need done? What does success look like?" style="min-height: 130px;"></textarea>
+			</div>
+			<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
+				<div class="form-group">
+					<label for="payout">Total payout (USD)</label>
+					<input id="payout" type="number" bind:value={payout} min="0" step="0.01" required placeholder="0.00" />
+				</div>
+				<div class="form-group">
+					<label for="timeline">Timeline (days)</label>
+					<input id="timeline" type="number" bind:value={timeline} min="1" step="1" placeholder="7" />
+				</div>
+			</div>
+		</div>
+
+		<div class="card" style="margin-bottom: 1.5rem;">
+			<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+				<h2 style="margin: 0; font-size: 1.1rem;">Milestones</h2>
+				<button type="button" class="btn btn-secondary" onclick={addMilestone} style="font-size: 0.85rem; padding: 0.35rem 0.9rem;">
+					+ Add milestone
+				</button>
+			</div>
+
+			{#each milestones as milestone, i}
+				<div class="milestone-row">
+					<div class="milestone-header">
+						<strong style="font-size: 0.9rem;">Milestone {i + 1}</strong>
+						{#if milestones.length > 1}
+							<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
+								Remove
+							</button>
+						{/if}
+					</div>
+					<div style="display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; align-items: start;">
+						<div class="form-group" style="margin-bottom: 0.5rem;">
+							<label for="m-title-{i}">Title</label>
+							<input id="m-title-{i}" type="text" bind:value={milestone.title} required placeholder="Milestone title" />
+						</div>
+						<div class="form-group" style="margin-bottom: 0.5rem;">
+							<label for="m-payout-{i}">Payout (USD)</label>
+							<input id="m-payout-{i}" type="number" bind:value={milestone.payout} min="0" step="0.01" placeholder="0.00" style="width: 130px;" />
+						</div>
+					</div>
+					<div>
+						<p style="font-size: 0.9rem; font-weight: 500; color: #333; margin: 0 0 0.5rem;">
+							Acceptance criteria
+						</p>
+						{#each milestone.criteria as criterion, ci}
+							<div style="display: flex; gap: 0.5rem; margin-bottom: 0.4rem;">
+								<input
+									type="text"
+									value={criterion}
+									oninput={(e) => updateCriteria(i, ci, (e.target as HTMLInputElement).value)}
+									placeholder="e.g. All tests pass, Page loads in under 2s"
+									style="flex: 1; padding: 0.4rem 0.6rem; border: 1px solid #ced4da; border-radius: 6px; font-size: 0.9rem;"
+								/>
+								{#if milestone.criteria.length > 1}
+									<button type="button" onclick={() => removeCriteria(i, ci)} style="background: none; border: none; color: #dc3545; cursor: pointer; font-size: 1.1rem; padding: 0 0.25rem;" title="Remove">×</button>
+								{/if}
+							</div>
+						{/each}
+						<button type="button" onclick={() => addCriteria(i)} style="background: none; border: none; color: #0066cc; cursor: pointer; font-size: 0.85rem; padding: 0.1rem 0; margin-top: 0.2rem;">
+							+ Add criterion
+						</button>
+					</div>
+				</div>
+			{/each}
+		</div>
+
+		<div style="display: flex; gap: 1rem;">
+			<button type="submit" class="btn btn-primary" disabled={submitting}>
+				{submitting ? 'Saving…' : 'Save Job Brief'}
+			</button>
+			<a href={returnTo} class="btn btn-secondary">Cancel</a>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
## Summary

Fixes #7 by fully implementing the updated hiring flow from the revised SPEC.

**Root cause:** The old flow required selecting an agent *before* writing a job brief, which was frustrating and blocked unverified users from saving their work. After the spec was updated (commit 3b274df), the backend was partially fixed but the frontend still used the old single-step hire flow.

**What changed:**

- **New `/jobs/new` page** — employers can write and save a full job brief (title, description, payout, timeline, milestones, acceptance criteria) without selecting an agent. Email verification is NOT required at this step.
- **Employer Dashboard** — always shows an "Enter a Job Brief" button. Empty state now shows a clear CTA. Unassigned jobs show a "Submit to Agent" button linking to the agent directory.
- **Agent profile page** — "Hire this agent" button now opens an inline modal that:
  - Lists existing unassigned job briefs with "Send Offer" buttons (one click to assign)
  - Shows "Enter a Job Brief" button if no unassigned jobs exist
- **Backend** — new `POST /api/ui/jobs/:id/assign` endpoint that assigns an agent to an existing unassigned job. Email verification is enforced at this step (when the agent relationship is initiated).

**New flow:**
1. Employer logs in → Dashboard → "Enter a Job Brief" → fills out form → saved (no agent yet)
2. Employer browses agents → clicks "Hire this agent" → modal shows their saved jobs → clicks "Send Offer"
3. Job status moves to `PENDING_ACCEPTANCE`, agent is notified

This matches the SPEC exactly: save the job first, gate on email verification only when assigning an agent.

## Test plan
- [ ] New employer (unverified email) can create a job brief via dashboard or `/jobs/new`
- [ ] Verified employer can assign an agent to a saved job via the agent profile modal
- [ ] Unverified employer trying to assign gets "Please verify your email" error
- [ ] Employer dashboard shows "Submit to Agent" for unassigned jobs
- [ ] "Send Offer" from modal correctly calls `/api/ui/jobs/:id/assign` and updates job status

🤖 Generated with [Claude Code](https://claude.com/claude-code)