### PR TITLE
fix: separate backend/frontend deployment into independent CI jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,14 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  test-and-deploy:
+  # ==========================================
+  # Detect which parts of the codebase changed
+  # ==========================================
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,30 +31,35 @@ jobs:
               - 'ops/**'
               - 'Containerfile'
             frontend:
-              - 'frontend/**' # FIXED: Watch the source code, not the static folder
+              - 'frontend/**'
 
-      # ==========================================
-      # BACKEND: Run Tests & Deploy (Only if backend changed)
-      # ==========================================
+  # ==========================================
+  # BACKEND: Run Tests & Deploy (Only if backend changed)
+  # ==========================================
+  deploy-backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Go
-        if: steps.filter.outputs.backend == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: '1.23' # Matches Containerfile
 
       - name: Run Go Tests
-        if: steps.filter.outputs.backend == 'true'
         run: cd backend && go test -v ./...
 
       - name: Deploy Backend to Server
-        if: success() && steps.filter.outputs.backend == 'true'
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
-          envs: GITHUB_SHA,DATABASE_URL,JWT_SECRET,RESEND_API_KEY
+          envs: GITHUB_SHA,DATABASE_URL,JWT_SECRET,RESEND_API_KEY,STRIPE_SECRET_KEY,STRIPE_WEBHOOK_SECRET
           script: |
             set -e
             SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-7)
@@ -62,6 +73,8 @@ jobs:
             DATABASE_URL=${DATABASE_URL}
             JWT_SECRET=${JWT_SECRET}
             RESEND_API_KEY=${RESEND_API_KEY}
+            STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}
+            STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
             EOF
 
             # Build and restart
@@ -75,26 +88,36 @@ jobs:
           DATABASE_URL: "./data/agentmarket.db"
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           GITHUB_SHA: ${{ github.sha }}
 
-      # ==========================================
-      # FRONTEND: Build & Deploy (Only if frontend changed)
-      # ==========================================
+  # ==========================================
+  # FRONTEND: Build & Deploy (Only if frontend changed)
+  # Runs independently of backend — a backend failure won't block frontend deployment.
+  # Static files are copied to a host directory that is bind-mounted into the container
+  # via the Quadlet config (see ops/webapp.container).
+  # ==========================================
+  deploy-frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup Node.js
-        if: success() && steps.filter.outputs.frontend == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Build Svelte Frontend
-        if: success() && steps.filter.outputs.frontend == 'true'
         working-directory: ./frontend
         run: |
           npm ci
           npm run build
 
       - name: Copy Build Artifacts to Server
-        if: success() && steps.filter.outputs.frontend == 'true'
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -102,13 +125,13 @@ jobs:
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           port: ${{ secrets.SSH_PORT }}
           source: "frontend/build/*"
-          target: "~/agentmarket/static"  # Avoid untracked files in git repo
+          # Host path that is bind-mounted into the container (see ops/webapp.container Volume=)
+          target: "~/agentmarket/static"
           strip_components: 2 # Strips "frontend/build/" from the destination path
           rm: true # Clean out previous hash-named files in the target dir before copying
           timeout: "3m"
 
-      - name: Sync Git Repo on Server (Frontend Only)
-        if: success() && steps.filter.outputs.frontend == 'true' && steps.filter.outputs.backend != 'true'
+      - name: Sync Git Repo on Server
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.SERVER_HOST }}
@@ -120,14 +143,18 @@ jobs:
             cd ~/agentmarket/agentmarket.git
             git pull origin main
 
-      # ==========================================
-      # NOTIFY: Discord Alert
-      # ==========================================
+  # ==========================================
+  # NOTIFY: Discord Alert (runs after both deploy jobs)
+  # ==========================================
+  notify:
+    needs: [deploy-backend, deploy-frontend]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
       - name: Notify Discord
-        if: always()
         uses: rjstone/discord-webhook-notify@v1
         with:
-          severity: ${{ job.status == 'success' && 'info' || 'error' }}
-          details: "Deployment of `${{ github.sha }}` to agentictemp.com: ${{ job.status }}"
+          severity: ${{ (needs.deploy-backend.result == 'failure' || needs.deploy-frontend.result == 'failure') && 'error' || 'info' }}
+          details: "Deployment of `${{ github.sha }}` to agentictemp.com — backend: ${{ needs.deploy-backend.result }}, frontend: ${{ needs.deploy-frontend.result }}"
           webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
 

--- a/ops/webapp.container
+++ b/ops/webapp.container
@@ -1,0 +1,35 @@
+# Podman Quadlet unit file for the AgentMarket web application.
+# Place this file at: ~/.config/containers/systemd/webapp.container
+# Then run: systemctl --user daemon-reload
+#
+# Static frontend files are NOT baked into the container image.
+# They are built by CI (see .github/workflows/deploy.yml, deploy-frontend job)
+# and copied via SCP to ~/agentmarket/static on the host.
+# The Volume= line below bind-mounts that host directory into the container at
+# /app/static, which is where the Go backend serves static files from.
+# This means frontend-only updates never require a container rebuild.
+
+[Unit]
+Description=AgentMarket web application
+After=network-online.target
+
+[Container]
+Image=localhost/webapp-image
+PublishPort=8080:8080
+
+# Bind-mount the host static dir into the container.
+# Frontend CI copies built files here; backend serves them from /app/static.
+Volume=%h/agentmarket/static:/app/static:z
+
+# Persist the SQLite database outside the container so it survives rebuilds.
+Volume=%h/agentmarket/data:/app/data:z
+
+# Load secrets from a separate env file (written by the backend CI deploy step).
+EnvironmentFile=%h/.config/containers/webapp.env
+
+[Service]
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Closes #8

## What changed

Restructures `deploy.yml` from a single sequential job into three parallel/dependent jobs:

1. **`changes`** — detects which paths changed (backend or frontend) and exposes outputs
2. **`deploy-backend`** — runs only when `backend/**`, `ops/**`, or `Containerfile` changed: runs Go tests, rebuilds the container image, restarts the Quadlet service
3. **`deploy-frontend`** — runs only when `frontend/**` changed: builds Svelte, copies static files via SCP to the host bind-mount directory, syncs the git repo; runs **fully independently** of the backend job so a backend failure never blocks a frontend-only deploy
4. **`notify`** — Discord alert that reports both job outcomes

## Why the old approach had a problem

The previous single-job design used `if: success() && steps.filter.outputs.frontend == 'true'` on the frontend steps. This worked for frontend-only pushes, but when both backend and frontend changed simultaneously, a backend test or deploy failure would prevent the frontend from deploying — even though the two deployments are logically independent.

## Additional fixes

- Added `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` to the env file written during backend deploy (they were in `config.go` but missing from CI)
- Added `ops/webapp.container` — a Podman Quadlet unit file that documents the `Volume=` bind-mount connecting `~/agentmarket/static` on the host to `/app/static` inside the container. This makes the "static files are NOT in the image" architecture explicit and the server setup reproducible from the repo.

## Test plan
- [ ] Push a frontend-only change → only `deploy-frontend` job runs
- [ ] Push a backend-only change → only `deploy-backend` job runs
- [ ] Push a change to both → both jobs run in parallel and independently
- [ ] Simulate a backend test failure with a simultaneous frontend change → frontend still deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)