### PR TITLE
fix: preserve formatting and render markdown in job brief

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,10 @@
 			"name": "frontend",
 			"version": "0.0.1",
 			"dependencies": {
-				"@sveltejs/adapter-static": "^3.0.10"
+				"@sveltejs/adapter-static": "^3.0.10",
+				"@types/dompurify": "^3.0.5",
+				"dompurify": "^3.3.3",
+				"marked": "^17.0.5"
 			},
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^7.0.0",
@@ -930,6 +933,15 @@
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/dompurify": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+			"integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/trusted-types": "*"
+			}
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1033,6 +1045,15 @@
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
 			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
 			"license": "MIT"
+		},
+		"node_modules/dompurify": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.27.4",
@@ -1153,6 +1174,18 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "17.0.5",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-17.0.5.tgz",
+			"integrity": "sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/mri": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,9 @@
 		"vite": "^7.3.1"
 	},
 	"dependencies": {
-		"@sveltejs/adapter-static": "^3.0.10"
+		"@sveltejs/adapter-static": "^3.0.10",
+		"@types/dompurify": "^3.0.5",
+		"dompurify": "^3.3.3",
+		"marked": "^17.0.5"
 	}
 }

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -3,8 +3,20 @@
 	import { page } from '$app/stores';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { browser } from '$app/environment';
+	import { marked } from 'marked';
+	import DOMPurify from 'dompurify';
 	import SOW from '$lib/components/SOW.svelte';
 	import DeliverySection from '$lib/components/DeliverySection.svelte';
+
+	function renderMarkdown(text: string): string {
+		const raw = marked.parse(text, { async: false }) as string;
+		if (browser) {
+			return DOMPurify.sanitize(raw);
+		}
+		// SSR: return parsed HTML; DOMPurify sanitizes after client hydration
+		return raw;
+	}
 
 	interface SOWData {
 		id?: string;
@@ -146,6 +158,30 @@
 	.badge-awaiting-payment { background: #fef3c7; color: #92400e; }
 	.badge-delivered { background: #dbeafe; color: #1e40af; }
 	.badge-cancelled { background: #fee2e2; color: #991b1b; }
+
+	/* Job brief: rendered markdown */
+	.job-brief {
+		max-width: 640px;
+		color: #444;
+		font-size: 0.95rem;
+		line-height: 1.6;
+	}
+	:global(.job-brief p) { margin: 0 0 0.6em; }
+	:global(.job-brief p:last-child) { margin-bottom: 0; }
+	:global(.job-brief h1),
+	:global(.job-brief h2),
+	:global(.job-brief h3),
+	:global(.job-brief h4) { margin: 0.8em 0 0.3em; font-size: 1rem; font-weight: 600; color: #222; }
+	:global(.job-brief ul),
+	:global(.job-brief ol) { margin: 0 0 0.6em 1.25rem; padding: 0; }
+	:global(.job-brief li) { margin-bottom: 0.2em; }
+	:global(.job-brief code) { background: #f3f4f6; padding: 0.1em 0.35em; border-radius: 3px; font-size: 0.875em; }
+	:global(.job-brief pre) { background: #f3f4f6; padding: 0.75rem 1rem; border-radius: 6px; overflow-x: auto; margin: 0 0 0.6em; }
+	:global(.job-brief pre code) { background: none; padding: 0; }
+	:global(.job-brief a) { color: #4f46e5; text-decoration: underline; }
+	:global(.job-brief blockquote) { border-left: 3px solid #d1d5db; margin: 0 0 0.6em 0; padding: 0.25em 0 0.25em 1em; color: #666; }
+	:global(.job-brief strong) { font-weight: 600; }
+	:global(.job-brief hr) { border: none; border-top: 1px solid #e5e7eb; margin: 0.8em 0; }
 </style>
 
 <div class="container page">
@@ -172,7 +208,7 @@
 					<span class="badge {statusBadgeClass(job.status)}">{statusLabel(job.status)}</span>
 				</div>
 				{#if job.description}
-					<p style="margin: 0; color: #666; max-width: 640px;">{job.description}</p>
+					<div class="job-brief">{@html renderMarkdown(job.description)}</div>
 				{/if}
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- Fixes #15: job brief text was rendered as unformatted plain text, collapsing all whitespace and linebreaks
- Installs `marked` (markdown parser) and `dompurify` (XSS sanitizer) as dependencies
- Adds a `renderMarkdown()` helper that parses the description as markdown and sanitizes the HTML output via DOMPurify on the client (secure against hostile user-submitted content)
- Replaces the plain `<p>{job.description}</p>` with `<div class="job-brief">{@html renderMarkdown(job.description)}</div>`
- Adds `.job-brief` CSS prose styles (paragraphs, headings, lists, code, blockquotes, links, horizontal rules)

## Test plan

- [ ] Open a job with markdown content in the brief (e.g. https://agentictemp.com/jobs/e8b80343-ccc2-474d-b4b4-25b0214d8583) and verify headings, lists, and linebreaks render correctly
- [ ] Verify plain-text descriptions (no markdown) still display cleanly
- [ ] Verify that a brief containing `<script>alert(1)</script>` is sanitized and does not execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)