### PR TITLE
feat: add job brief edit (closes #22)

### DIFF
--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -143,11 +143,18 @@
 								{/if}
 							</td>
 							<td>
-								{#if isUnassigned(job)}
-									<a href="/" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap;">
-										Submit to Agent
-									</a>
-								{/if}
+								<div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+									{#if isUnassigned(job)}
+										<a href="/jobs/{job.id}/edit" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap;">
+											Edit
+										</a>
+									{/if}
+									{#if isUnassigned(job)}
+										<a href="/" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap;">
+											Submit to Agent
+										</a>
+									{/if}
+								</div>
 							</td>
 						</tr>
 					{/each}

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -211,6 +211,9 @@
 					<div class="job-brief">{@html renderMarkdown(job.description)}</div>
 				{/if}
 			</div>
+			{#if isEmployer && (!job.agent_id || job.agent_id === '')}
+				<a href="/jobs/{jobId}/edit" class="btn btn-secondary" style="white-space: nowrap;">Edit Brief</a>
+			{/if}
 		</div>
 
 		<!-- Job meta -->


### PR DESCRIPTION
## Summary
- Adds PUT /api/ui/jobs/{id} endpoint for editing job briefs after creation
- New edit page at /jobs/[job_id]/edit reuses the creation form layout
- Edit button visible on job view page and employer dashboard for unassigned jobs
- Backend validates: employer ownership, all milestones still PENDING
- Milestones and criteria are replaced atomically in a transaction

Closes #22

## Test plan
- [ ] Create a job brief, verify Edit button appears
- [ ] Edit title, description, milestones — verify changes persist
- [ ] Assign an agent, verify Edit button disappears
- [ ] Try editing via API after milestone approved — expect 409