### PR TITLE
fix: centralize site title in config (#24)

### DIFF
--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,1 @@
+export const SITE_NAME = 'AgentMarket';

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
 	import '../app.css';
 	import { auth, isAuthenticated } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	let { children } = $props();
 
@@ -13,7 +14,7 @@
 
 <nav>
 	<div class="nav-inner">
-		<a class="brand" href="/">Agentic Temp Market</a>
+		<a class="brand" href="/">{SITE_NAME}</a>
 		<a href="/">Agents</a>
 		{#if $isAuthenticated}
 			{#if $auth?.role === 'EMPLOYER'}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { isAuthenticated, auth } from '$lib/stores/auth';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Agent {
 		id: string;
@@ -31,12 +32,12 @@
 </script>
 
 <svelte:head>
-	<title>Agentic Temp Market — Hire AI Agents</title>
+	<title>{SITE_NAME} — Hire AI Agents</title>
 </svelte:head>
 
 <div class="container page">
 	<div class="page-header">
-		<h1>Agentic Temp Market</h1>
+		<h1>{SITE_NAME}</h1>
 		<p>Browse and hire AI agents for your projects. Managed by human handlers, built for results.</p>
 	</div>
 

--- a/frontend/src/routes/agents/[id]/+page.svelte
+++ b/frontend/src/routes/agents/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { isAuthenticated, auth, apiFetch } from '$lib/stores/auth';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Agent {
 		id: string;
@@ -102,7 +103,7 @@
 </script>
 
 <svelte:head>
-	<title>{agent?.name ?? 'Agent'} — AgentMarket</title>
+	<title>{agent?.name ?? 'Agent'} — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="container page">

--- a/frontend/src/routes/auth/forgot-password/+page.svelte
+++ b/frontend/src/routes/auth/forgot-password/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { SITE_NAME } from '$lib/config';
 	let email = $state('');
 	let loading = $state(false);
 	let submitted = $state(false);
@@ -28,7 +29,7 @@
 </script>
 
 <svelte:head>
-	<title>Forgot Password — AgentMarket</title>
+	<title>Forgot Password — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="auth-wrap">

--- a/frontend/src/routes/auth/login/+page.svelte
+++ b/frontend/src/routes/auth/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	let email = $state('');
 	let password = $state('');
@@ -23,7 +24,7 @@
 </script>
 
 <svelte:head>
-	<title>Login — AgentMarket</title>
+	<title>Login — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="auth-wrap">

--- a/frontend/src/routes/auth/reset-password/+page.svelte
+++ b/frontend/src/routes/auth/reset-password/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	let token = $state('');
 	let newPassword = $state('');
@@ -48,7 +49,7 @@
 </script>
 
 <svelte:head>
-	<title>Reset Password — AgentMarket</title>
+	<title>Reset Password — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="auth-wrap">

--- a/frontend/src/routes/auth/signup/+page.svelte
+++ b/frontend/src/routes/auth/signup/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	let name = $state('');
 	let handle = $state('');
@@ -30,7 +31,7 @@
 </script>
 
 <svelte:head>
-	<title>Sign up — AgentMarket</title>
+	<title>Sign up — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="auth-wrap">

--- a/frontend/src/routes/auth/verify-email/+page.svelte
+++ b/frontend/src/routes/auth/verify-email/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { SITE_NAME } from '$lib/config';
 
 	let status: 'pending' | 'success' | 'error' = $state('pending');
 	let message = $state('');
@@ -34,7 +35,7 @@
 </script>
 
 <svelte:head>
-	<title>Verify Email — AgentMarket</title>
+	<title>Verify Email — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="auth-wrap">

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Milestone {
 		id: string;
@@ -78,7 +79,7 @@
 </script>
 
 <svelte:head>
-	<title>Employer Dashboard — AgentMarket</title>
+	<title>Employer Dashboard — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="container page">

--- a/frontend/src/routes/dashboard/handler/+page.svelte
+++ b/frontend/src/routes/dashboard/handler/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Agent {
 		id: string;
@@ -118,7 +119,7 @@
 </script>
 
 <svelte:head>
-	<title>Handler Dashboard — AgentMarket</title>
+	<title>Handler Dashboard — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="container page">

--- a/frontend/src/routes/hire/[agent_id]/+page.svelte
+++ b/frontend/src/routes/hire/[agent_id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/stores';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Milestone {
 		title: string;
@@ -114,7 +115,7 @@
 </script>
 
 <svelte:head>
-	<title>Hire {agent?.name ?? 'Agent'} — AgentMarket</title>
+	<title>Hire {agent?.name ?? 'Agent'} — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="container page">

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -8,6 +8,7 @@
 	import DOMPurify from 'dompurify';
 	import SOW from '$lib/components/SOW.svelte';
 	import DeliverySection from '$lib/components/DeliverySection.svelte';
+	import { SITE_NAME } from '$lib/config';
 
 	function renderMarkdown(text: string): string {
 		const raw = marked.parse(text, { async: false }) as string;
@@ -158,7 +159,7 @@
 </script>
 
 <svelte:head>
-	<title>{job?.title ?? 'Job'} — AgentMarket</title>
+	<title>{job?.title ?? 'Job'} — {SITE_NAME}</title>
 </svelte:head>
 
 <style>

--- a/frontend/src/routes/jobs/new/+page.svelte
+++ b/frontend/src/routes/jobs/new/+page.svelte
@@ -3,6 +3,7 @@
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
+	import { SITE_NAME } from '$lib/config';
 
 	// Stepped auto-resize for textareas: grows in ROW_STEP-line increments, not per keystroke.
 	const ROW_STEP = 3;
@@ -123,7 +124,7 @@
 </script>
 
 <svelte:head>
-	<title>Enter a Job Brief — AgentMarket</title>
+	<title>Enter a Job Brief — {SITE_NAME}</title>
 </svelte:head>
 
 <div class="container page">

--- a/frontend/src/routes/transactions/+page.svelte
+++ b/frontend/src/routes/transactions/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
+	import { SITE_NAME } from '$lib/config';
 
 	interface Transaction {
 		id: string;
@@ -81,7 +82,7 @@
 </script>
 
 <svelte:head>
-	<title>Transactions — AgentMarket</title>
+	<title>Transactions — {SITE_NAME}</title>
 </svelte:head>
 
 <style>


### PR DESCRIPTION
## Summary

- Add `frontend/src/lib/config.ts` exporting `SITE_NAME = 'AgentMarket'`
- Update all 15 `.svelte` files to import `SITE_NAME` from `$lib/config` and use it in `<title>` tags and inline text (nav brand link, h1 on home page)
- Fixes #24: site title is now defined in one place — changing `SITE_NAME` in `config.ts` propagates everywhere automatically

## Files changed

- **New**: `frontend/src/lib/config.ts`
- **Modified**: `+layout.svelte`, `+page.svelte`, and 13 route-level pages across auth, agents, hire, dashboard, jobs, and transactions

## Test plan

- [ ] Verify browser tab titles show "AgentMarket" on all pages
- [ ] Verify nav brand link shows "AgentMarket"
- [ ] Verify home page h1 shows "AgentMarket"
- [ ] Confirm changing `SITE_NAME` in `config.ts` updates all titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)