### PR TITLE
fix: add Open Graph meta tags for rich link previews

### DIFF
--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -3,6 +3,21 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+		<!-- Open Graph / Facebook -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content="https://agentictemp.com" />
+		<meta property="og:title" content="AgentMarket - Find AI Agents" />
+		<meta property="og:description" content="Discover and hire AI agents for your tasks" />
+		<meta property="og:image" content="https://agentictemp.com/og-image.svg" />
+
+		<!-- Twitter Card -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:url" content="https://agentictemp.com" />
+		<meta name="twitter:title" content="AgentMarket - Find AI Agents" />
+		<meta name="twitter:description" content="Discover and hire AI agents for your tasks" />
+		<meta name="twitter:image" content="https://agentictemp.com/og-image.svg" />
+
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/frontend/static/og-image.svg
+++ b/frontend/static/og-image.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <rect width="1200" height="630" fill="#0f172a"/>
+  <text x="600" y="280" font-family="system-ui, sans-serif" font-size="72" font-weight="bold" fill="#ffffff" text-anchor="middle">AgentMarket</text>
+  <text x="600" y="370" font-family="system-ui, sans-serif" font-size="36" fill="#94a3b8" text-anchor="middle">Discover and hire AI agents for your tasks</text>
+</svg>


### PR DESCRIPTION
Closes #26.

## What changed

- Added Open Graph and Twitter Card meta tags to `frontend/src/app.html` so messaging apps (Slack, iMessage, Discord, etc.) display rich link previews when the site URL is pasted
- Added a placeholder `frontend/static/og-image.svg` (1200x630, dark background) as the OG image — this should be replaced with a real designed image before launch

## Meta tags added

| Tag | Value |
|-----|-------|
| og:type | website |
| og:url | https://agentictemp.com |
| og:title | AgentMarket - Find AI Agents |
| og:description | Discover and hire AI agents for your tasks |
| og:image | https://agentictemp.com/og-image.svg |
| twitter:card | summary_large_image |
| twitter:title / description / image | (same as OG) |

## SSR note

`frontend/src/routes/+layout.ts` has `ssr = false` and `prerender = false`. This means the app is a pure client-side SPA. Crawlers that don't execute JavaScript (including some unfurl bots) will receive the raw HTML from `app.html` — which is exactly where these static OG tags live, so basic unfurls will work. However, page-specific OG tags (e.g. per-agent pages) won't be visible to non-JS crawlers. Consider enabling SSR (`ssr = true`) for better SEO and dynamic OG support, but that may require backend/auth changes to be evaluated separately.

## Testing

Paste `https://agentictemp.com` in Slack, Discord, or iMessage after deploy — you should see a card with the title, description, and OG image.