### PR TITLE
fix: display agent name on employer dashboard instead of internal ID

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -42,6 +42,7 @@ type Job struct {
 	ID                  string      `json:"id"`
 	EmployerID          string      `json:"employer_id"`
 	AgentID             string      `json:"agent_id"`
+	AgentName           string      `json:"agent_name,omitempty"`
 	Status              string      `json:"status"`
 	Title               string      `json:"title"`
 	Description         string      `json:"description"`
@@ -143,6 +144,18 @@ func (app *App) scanJob(row interface{ Scan(...interface{}) error }) (Job, error
 	var stripe sql.NullString
 	err := row.Scan(&j.ID, &j.EmployerID, &j.AgentID, &j.Status, &j.Title, &j.Description,
 		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt)
+	if stripe.Valid {
+		j.StripePaymentIntent = stripe.String
+	}
+	return j, err
+}
+
+// scanJobWithName scans a job row that includes an extra agent_name column at the end.
+func (app *App) scanJobWithName(row interface{ Scan(...interface{}) error }) (Job, error) {
+	var j Job
+	var stripe sql.NullString
+	err := row.Scan(&j.ID, &j.EmployerID, &j.AgentID, &j.Status, &j.Title, &j.Description,
+		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt, &j.AgentName)
 	if stripe.Valid {
 		j.StripePaymentIntent = stripe.String
 	}
@@ -484,15 +497,19 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 	var err error
 
 	if role == "EMPLOYER" {
+		// JOIN agents so we can return the agent name alongside agent_id
 		rows, err = app.DB.Query(
-			`SELECT id, employer_id, agent_id, status, title, description, total_payout, timeline_days, stripe_payment_intent, created_at, updated_at
-			 FROM jobs WHERE employer_id = ? ORDER BY created_at DESC`,
+			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
+			 FROM jobs j
+			 LEFT JOIN agents a ON j.agent_id = a.id
+			 WHERE j.employer_id = ?
+			 ORDER BY j.created_at DESC`,
 			userID,
 		)
 	} else {
 		// AGENT_HANDLER: list jobs for any of their agents
 		rows, err = app.DB.Query(
-			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at
+			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
 			 FROM jobs j
 			 JOIN agents a ON j.agent_id = a.id
 			 WHERE a.handler_id = ?
@@ -509,7 +526,7 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	jobs := []Job{}
 	for rows.Next() {
-		j, err := app.scanJob(rows)
+		j, err := app.scanJobWithName(rows)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "scan error")
 			return
@@ -523,11 +540,13 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 
 func (app *App) getJobDetail(jobID string) (Job, error) {
 	row := app.DB.QueryRow(
-		`SELECT id, employer_id, agent_id, status, title, description, total_payout, timeline_days, stripe_payment_intent, created_at, updated_at
-		 FROM jobs WHERE id = ?`,
+		`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
+		 FROM jobs j
+		 LEFT JOIN agents a ON j.agent_id = a.id
+		 WHERE j.id = ?`,
 		jobID,
 	)
-	j, err := app.scanJob(row)
+	j, err := app.scanJobWithName(row)
 	if err != nil {
 		return j, err
 	}

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -19,6 +19,7 @@
 		id: string;
 		employer_id: string;
 		agent_id: string;
+		agent_name: string;
 		title: string;
 		description: string;
 		status: string;
@@ -129,7 +130,7 @@
 								{#if isUnassigned(job)}
 									<span style="color: #aaa; font-style: italic; font-size: 0.9rem;">Not assigned</span>
 								{:else}
-									<a href="/agents/{job.agent_id}">Agent #{job.agent_id.slice(0, 8)}</a>
+									<a href="/agents/{job.agent_id}">{job.agent_name || job.agent_id.slice(0, 8)}</a>
 								{/if}
 							</td>
 							<td>


### PR DESCRIPTION
## Summary

Fixes #36 — the employer dashboard was showing agents as `Agent #61f5f22b` (a truncated internal UUID) instead of their registered name.

**Root cause:** `ListJobsHandler` and `getJobDetail` only returned `agent_id` from the `jobs` table; the frontend had no name to display, so it fell back to slicing the UUID.

**Changes:**

- **`backend/jobs.go`**
  - Added `AgentName string` field to the `Job` struct (`json:"agent_name,omitempty"`)
  - Added `scanJobWithName` helper that scans the extra `agent_name` column returned by JOIN queries
  - Updated `ListJobsHandler` (both EMPLOYER and AGENT_HANDLER branches) to `LEFT JOIN agents` and select `COALESCE(a.name, '')` as the agent name
  - Updated `getJobDetail` (used by hire, assign, accept, decline, deliver, approve, revise endpoints) to do the same JOIN so all job responses include the agent name

- **`frontend/src/routes/dashboard/employer/+page.svelte`**
  - Added `agent_name: string` to the `Job` TypeScript interface
  - Changed the agent cell from `Agent #{job.agent_id.slice(0, 8)}` to `{job.agent_name || job.agent_id.slice(0, 8)}` — shows the name when present, gracefully falls back to the short ID

## Test plan

- [ ] Create a job assigned to an agent — employer dashboard should show the agent's name (e.g. "My Bot") instead of `Agent #61f5f22b`
- [ ] Unassigned jobs still show "Not assigned" (unchanged path)
- [ ] Existing Go unit tests (`go test ./...`) continue to pass — `scanJob` is unchanged; only new queries use `scanJobWithName`

🤖 Generated with [Claude Code](https://claude.com/claude-code)