### PR TITLE
feat: add Retract Offer button for pending job offers

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -112,7 +112,28 @@ func RunMigrations(db *sql.DB) error {
 		 SELECT id, employer_id, agent_id, status, title, description, total_payout, timeline_days, stripe_payment_intent, created_at, updated_at FROM jobs`,
 		`DROP TABLE IF EXISTS jobs`,
 		`ALTER TABLE jobs_new RENAME TO jobs`,
-		// M2: sow table
+		// M3: add RETRACTED status — recreate jobs table with expanded CHECK constraint
+		`CREATE TABLE IF NOT EXISTS jobs_retracted (
+			id TEXT PRIMARY KEY,
+			employer_id TEXT NOT NULL REFERENCES users(id),
+			agent_id TEXT NOT NULL REFERENCES agents(id),
+			status TEXT NOT NULL DEFAULT 'PENDING_ACCEPTANCE' CHECK(status IN ('PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED','SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED')),
+			title TEXT NOT NULL,
+			description TEXT DEFAULT '',
+			total_payout INTEGER NOT NULL,
+			timeline_days INTEGER NOT NULL,
+			stripe_payment_intent TEXT,
+			stripe_checkout_session_id TEXT,
+			delivered_at DATETIME,
+			delivery_notes TEXT,
+			delivery_url TEXT,
+			created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)`,
+		`INSERT OR IGNORE INTO jobs_retracted SELECT * FROM jobs`,
+		`DROP TABLE IF EXISTS jobs`,
+		`ALTER TABLE jobs_retracted RENAME TO jobs`,
+		// M3: sow table
 		`CREATE TABLE IF NOT EXISTS sow (
 			id TEXT PRIMARY KEY,
 			job_id TEXT NOT NULL REFERENCES jobs(id),

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1025,6 +1025,52 @@ func (app *App) RequestRevisionHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(j)
 }
 
+// RetractOfferHandler allows an employer to retract a pending job offer.
+// The offer must be in PENDING_ACCEPTANCE status (i.e. sent to an agent but not yet accepted).
+// POST /api/ui/jobs/{id}/retract
+func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "retract_offer")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "EMPLOYER" {
+		log.Warn("authz failure: retract offer requires EMPLOYER role", "role", role)
+		writeError(w, http.StatusForbidden, "only EMPLOYER role can retract offers")
+		return
+	}
+
+	employerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "id")
+
+	result, err := app.DB.Exec(
+		`UPDATE jobs SET status = 'RETRACTED', agent_id = '', updated_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND employer_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		jobID, employerID,
+	)
+	if err != nil {
+		log.Error("retract offer failed: database error", "job_id", jobID, "employer_id", employerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "job not found, not owned by you, or not in PENDING_ACCEPTANCE status")
+		return
+	}
+
+	log.Info("offer retracted", "job_id", jobID, "employer_id", employerID)
+
+	j, err := app.getJobDetail(jobID)
+	if err != nil {
+		log.Error("retract offer: failed to retrieve after update", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve job")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(j)
+}
+
 // TransactionSummary is a lightweight view of a job for transaction listing.
 type TransactionSummary struct {
 	JobID               string `json:"job_id"`

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -231,3 +231,94 @@ func TestGetPendingJobs(t *testing.T) {
 		t.Errorf("expected 2 pending jobs, got %d", len(jobs))
 	}
 }
+
+func TestRetractOffer(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, _, agentID, _ := setupJobFixtures(t, app)
+	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	// Create a job with agent assigned (PENDING_ACCEPTANCE)
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
+		HireRequest{AgentID: agentID, Title: "Job to retract", TotalPayout: 500, TimelineDays: 3},
+		employerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("hire: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status != "PENDING_ACCEPTANCE" {
+		t.Fatalf("expected PENDING_ACCEPTANCE status, got %q", job.Status)
+	}
+
+	// Retract the offer
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("retract: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var retracted Job
+	json.Unmarshal(rr.Body.Bytes(), &retracted)
+	if retracted.Status != "RETRACTED" {
+		t.Errorf("expected RETRACTED status, got %q", retracted.Status)
+	}
+	if retracted.AgentID != "" {
+		t.Errorf("expected agent_id to be cleared, got %q", retracted.AgentID)
+	}
+
+	// Retracting again should fail (no longer PENDING_ACCEPTANCE)
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("double-retract: expected 404, got %d", rr.Code)
+	}
+}
+
+func TestRetractOfferWrongEmployer(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, _, agentID, _ := setupJobFixtures(t, app)
+	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	// Create a job
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
+		HireRequest{AgentID: agentID, Title: "Someone else job", TotalPayout: 100, TimelineDays: 1},
+		employerToken)
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+
+	// Different employer tries to retract
+	otherEmployerID, _ := createVerifiedTestUser(t, app, "EMPLOYER")
+	otherToken := makeAuthToken(t, app, otherEmployerID, "EMPLOYER")
+
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, otherToken)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("wrong employer: expected 404, got %d", rr.Code)
+	}
+}
+
+func TestRetractOfferNonPending(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, _, agentID, apiKey := setupJobFixtures(t, app)
+	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	// Create and accept a job (moves to SOW_NEGOTIATION)
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
+		HireRequest{AgentID: agentID, Title: "Accepted job", TotalPayout: 200, TimelineDays: 2},
+		employerToken)
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+
+	doRequest(t, router, http.MethodPost, "/api/v1/jobs/"+job.ID+"/accept", nil, apiKey)
+
+	// Employer tries to retract after acceptance
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("non-pending retract: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -114,6 +114,7 @@ func NewRouter(app *App) *chi.Mux {
 				r.Get("/{job_id}/sow", app.GetSOW)
 				r.Post("/{job_id}/sow/accept", app.AcceptSOW)
 				r.Post("/{job_id}/checkout", app.CreateCheckoutHandler)
+				r.Post("/{id}/retract", app.RetractOfferHandler)
 				r.Post("/{job_id}/approve-delivery", app.ApproveDeliveryHandler)
 				r.Post("/{job_id}/request-revision", app.RequestRevisionHandler)
 			})

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -33,6 +33,8 @@
 	let jobs: Job[] = $state([]);
 	let loading = $state(true);
 	let error = $state('');
+	let retractingJobId = $state<string | null>(null);
+	let retractError = $state('');
 
 	function statusBadge(status: string): string {
 		const map: Record<string, string> = {
@@ -44,7 +46,8 @@
 			COMPLETED: 'badge-completed',
 			PENDING: 'badge-pending',
 			PENDING_ACCEPTANCE: 'badge-pending',
-			CANCELLED: 'badge-cancelled'
+			CANCELLED: 'badge-cancelled',
+			RETRACTED: 'badge-cancelled'
 		};
 		return map[status] ?? 'badge-pending';
 	}
@@ -55,6 +58,26 @@
 
 	function isUnassigned(job: Job): boolean {
 		return !job.agent_id || job.agent_id === '';
+	}
+
+	async function retractOffer(jobId: string) {
+		if (!confirm('Are you sure you want to retract this offer?')) return;
+		retractingJobId = jobId;
+		retractError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/retract`, { method: 'POST' });
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to retract offer' }));
+				throw new Error(err.error || 'Failed to retract offer');
+			}
+			// Refresh jobs list
+			const listRes = await apiFetch('/api/ui/jobs');
+			if (listRes.ok) jobs = await listRes.json();
+		} catch (e: unknown) {
+			retractError = e instanceof Error ? e.message : 'Failed to retract offer';
+		} finally {
+			retractingJobId = null;
+		}
 	}
 
 	onMount(async () => {
@@ -90,6 +113,10 @@
 		</div>
 		<a href="/jobs/new" class="btn btn-primary">Enter a Job Brief</a>
 	</div>
+
+	{#if retractError}
+		<div class="alert alert-error" style="margin-bottom: 1rem;">{retractError}</div>
+	{/if}
 
 	{#if loading}
 		<p style="color: #888; padding: 2rem 0;">Loading jobs...</p>
@@ -154,6 +181,16 @@
 										<a href="/" class="btn btn-secondary" style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap;">
 											Submit to Agent
 										</a>
+									{/if}
+									{#if job.status === 'PENDING_ACCEPTANCE'}
+										<button
+											class="btn btn-secondary"
+											style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap; color: #991b1b; border-color: #fca5a5;"
+											onclick={() => retractOffer(job.id)}
+											disabled={retractingJobId === job.id}
+										>
+											{retractingJobId === job.id ? 'Retracting…' : 'Retract Offer'}
+										</button>
 									{/if}
 								</div>
 							</td>

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -80,6 +80,8 @@
 	let error = $state('');
 	let checkoutLoading = $state(false);
 	let checkoutError = $state('');
+	let retractLoading = $state(false);
+	let retractError = $state('');
 
 	const isEmployer = $derived($auth?.role === 'EMPLOYER');
 	const isHandler = $derived($auth?.role === 'AGENT_HANDLER');
@@ -93,7 +95,9 @@
 			DELIVERED: 'badge-delivered',
 			COMPLETED: 'badge-completed',
 			PENDING: 'badge-pending',
-			CANCELLED: 'badge-cancelled'
+			PENDING_ACCEPTANCE: 'badge-pending',
+			CANCELLED: 'badge-cancelled',
+			RETRACTED: 'badge-cancelled'
 		};
 		return map[status] ?? 'badge-pending';
 	}
@@ -146,6 +150,24 @@
 			checkoutError = e instanceof Error ? e.message : 'Failed to initiate checkout';
 		} finally {
 			checkoutLoading = false;
+		}
+	}
+
+	async function handleRetractOffer() {
+		if (!confirm('Are you sure you want to retract this offer? The agent will no longer be assigned.')) return;
+		retractLoading = true;
+		retractError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/retract`, { method: 'POST' });
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to retract offer' }));
+				throw new Error(err.error || 'Failed to retract offer');
+			}
+			await loadJob();
+		} catch (e: unknown) {
+			retractError = e instanceof Error ? e.message : 'Failed to retract offer';
+		} finally {
+			retractLoading = false;
 		}
 	}
 
@@ -222,6 +244,21 @@
 			</div>
 			{#if isEmployer && (!job.agent_id || job.agent_id === '')}
 				<a href="/jobs/{jobId}/edit" class="btn btn-secondary" style="white-space: nowrap;">Edit Brief</a>
+			{/if}
+			{#if isEmployer && job.status === 'PENDING_ACCEPTANCE'}
+				<div>
+					{#if retractError}
+						<div class="alert alert-error" style="margin-bottom: 0.5rem;">{retractError}</div>
+					{/if}
+					<button
+						class="btn btn-secondary"
+						style="white-space: nowrap; color: #991b1b; border-color: #fca5a5;"
+						onclick={handleRetractOffer}
+						disabled={retractLoading}
+					>
+						{retractLoading ? 'Retracting…' : 'Retract Offer'}
+					</button>
+				</div>
 			{/if}
 		</div>
 


### PR DESCRIPTION
## Summary

- Adds a **Retract Offer** button visible to employers on the job detail page and the employer dashboard, shown only when the job is in `PENDING_ACCEPTANCE` status
- Clicking the button sends `POST /api/ui/jobs/{id}/retract`, which sets status to `RETRACTED` and clears the `agent_id`, freeing the employer to re-send the offer once notifications land
- Only the owning employer can retract, and only while the offer is still pending (guards: wrong employer → 404, already accepted → 404)
- DB migration (M3) extends the `status` CHECK constraint on the `jobs` table to include `RETRACTED`

## Changes

- `backend/jobs.go` — `RetractOfferHandler`
- `backend/router.go` — route registered at `POST /api/ui/jobs/{id}/retract`
- `backend/db.go` — migration adds `RETRACTED` to job status CHECK constraint
- `backend/jobs_test.go` — three new tests (happy path, wrong employer, non-pending state)
- `frontend/src/routes/jobs/[job_id]/+page.svelte` — Retract Offer button on job detail
- `frontend/src/routes/dashboard/employer/+page.svelte` — Retract Offer button in dashboard table

## Test plan

- [ ] As an employer, create a job and assign an agent — job enters `PENDING_ACCEPTANCE`
- [ ] Verify the **Retract Offer** button appears on the job detail page and employer dashboard
- [ ] Click Retract Offer — confirm dialog appears, then job transitions to `RETRACTED` and agent is unassigned
- [ ] Verify the button does **not** appear for jobs in other statuses (e.g. `SOW_NEGOTIATION`, `IN_PROGRESS`)
- [ ] Verify a different employer cannot retract another employer's offer
- [ ] Run backend tests: `go test ./...` — all pass

Closes #35