### PR TITLE
fix: SOW display bug (Issue #40)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -52,6 +52,7 @@ type Job struct {
 	CreatedAt           time.Time   `json:"created_at"`
 	UpdatedAt           time.Time   `json:"updated_at"`
 	Milestones          []Milestone `json:"milestones,omitempty"`
+	SOW                 *SOW        `json:"sow"`
 }
 
 // --- Request types ---
@@ -576,6 +577,14 @@ func (app *App) getJobDetail(jobID string) (Job, error) {
 		return j, err
 	}
 	j.Milestones = milestones
+
+	sow, err := app.getSOWByJobID(jobID)
+	if err == nil {
+		j.SOW = &sow
+	} else if err != sql.ErrNoRows {
+		slog.Warn("failed to fetch SOW for job", "job_id", jobID, "error", err)
+	}
+
 	return j, nil
 }
 

--- a/frontend/src/lib/components/SOW.svelte
+++ b/frontend/src/lib/components/SOW.svelte
@@ -9,9 +9,9 @@
 		price_cents: number;
 		timeline_days: number;
 		employer_accepted: boolean;
-		handler_accepted: boolean;
+		agent_accepted: boolean;
 		employer_accepted_at?: string;
-		handler_accepted_at?: string;
+		agent_accepted_at?: string;
 	}
 
 	interface Props {
@@ -142,10 +142,10 @@
 
 	// Check if current user already accepted
 	const userAccepted = $derived(
-		sow && ((isEmployer && sow.employer_accepted) || (isHandler && sow.handler_accepted))
+		sow && ((isEmployer && sow.employer_accepted) || (isHandler && sow.agent_accepted))
 	);
 
-	const bothAccepted = $derived(sow && sow.employer_accepted && sow.handler_accepted);
+	const bothAccepted = $derived(sow && sow.employer_accepted && sow.agent_accepted);
 </script>
 
 <div class="card" style="margin-bottom: 1.5rem;">
@@ -224,8 +224,8 @@
 						<span>Employer: {sow.employer_accepted ? 'Accepted' : 'Pending'}</span>
 					</div>
 					<div style="display: flex; align-items: center; gap: 0.4rem; font-size: 0.9rem;">
-						<span style="width: 10px; height: 10px; border-radius: 50%; background: {sow.handler_accepted ? '#10b981' : '#e5e7eb'}; display: inline-block;"></span>
-						<span>Handler: {sow.handler_accepted ? 'Accepted' : 'Pending'}</span>
+						<span style="width: 10px; height: 10px; border-radius: 50%; background: {sow.agent_accepted ? '#10b981' : '#e5e7eb'}; display: inline-block;"></span>
+						<span>Handler: {sow.agent_accepted ? 'Accepted' : 'Pending'}</span>
 					</div>
 				</div>
 			</div>

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -27,9 +27,9 @@
 		price_cents: number;
 		timeline_days: number;
 		employer_accepted: boolean;
-		handler_accepted: boolean;
+		agent_accepted: boolean;
 		employer_accepted_at?: string;
-		handler_accepted_at?: string;
+		agent_accepted_at?: string;
 	}
 
 	interface DeliveryData {


### PR DESCRIPTION
## Summary
- Include SOW data in GET /api/ui/jobs/:id response (was missing entirely)
- Fix field name mismatch: frontend used handler_accepted but backend returns agent_accepted

## Root Cause
The Job struct and getJobDetail() never fetched or included SOW data. After saving a SOW, the subsequent loadJob() call would return null for the SOW field, making it appear the SOW was never saved.

## Changes
- backend/jobs.go: Add SOW field to Job struct, populate in getJobDetail()
- frontend SOW.svelte + page.svelte: Rename handler_accepted → agent_accepted

Closes #40