### PR TITLE
fix: embed SQLite PRAGMAs in DSN and add connection pool limits (#42)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -14,15 +16,24 @@ func InitDB(cfg *Config) (*sql.DB, error) {
 		dsn = "./data/agentmarket.db"
 	}
 
+	// Embed PRAGMAs in the DSN so they apply to every connection in the pool,
+	// not just the first one. Fixes #42: foreign_keys was silently disabled for
+	// most requests when set via a standalone db.Exec call.
+	sep := "?"
+	if strings.Contains(dsn, "?") {
+		sep = "&"
+	}
+	dsn += sep + "_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=foreign_keys(1)"
+
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
 
-	// Enable WAL mode for better concurrent performance
-	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
-		return nil, fmt.Errorf("failed to enable WAL mode: %w", err)
-	}
+	// Limit the connection pool so SQLite's write-lock contention stays bounded.
+	db.SetMaxOpenConns(25)
+	db.SetMaxIdleConns(25)
+	db.SetConnMaxLifetime(5 * time.Minute)
 
 	slog.Info("database initialized", "dsn", dsn)
 	return db, nil


### PR DESCRIPTION
## Problem

`InitDB` called `db.Exec("PRAGMA journal_mode=WAL")` after opening the connection pool. With `database/sql`'s pool, that exec runs on **one** connection. Every other connection in the pool silently receives no PRAGMAs at all — meaning `foreign_keys` enforcement was disabled for most requests. Closes #42.

## Fix

- **Embed PRAGMAs in the DSN** using the `_pragma` query parameter so every new connection the pool opens automatically applies `journal_mode(WAL)`, `busy_timeout(5000)`, and `foreign_keys(1)`.
- **Safe DSN append**: checks for an existing `?` before appending, so the fix is compatible with the in-memory test DSN (`file:testmem%d?mode=memory&cache=shared`) without producing a malformed URL.
- **Connection pool limits**: added `SetMaxOpenConns(25)`, `SetMaxIdleConns(25)`, `SetConnMaxLifetime(5m)` to bound write-lock contention under load.
- **Removed** the now-redundant standalone `db.Exec("PRAGMA journal_mode=WAL")` call.

## Changes

`backend/db.go` only — no schema changes, no migration required.

## Test plan

- [ ] Existing test suite (`go test ./...`) passes — in-memory DSN already has `?mode=memory&cache=shared`, so the `&` separator path is exercised automatically.
- [ ] Manually verify `PRAGMA foreign_keys` returns `1` on a freshly opened connection from the pool after the change.
- [ ] Confirm WAL mode is active on the production DB file after restart.