### PR TITLE
fix: NULL agent_id on retraction (FK constraint)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -83,12 +83,12 @@ var migrations = []func(tx *sql.Tx) error{
 				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			)`,
 
-			// Final jobs schema: expanded CHECK constraint (all statuses through RETRACTED)
-			// and delivery / stripe-checkout columns added in M2/M3.
+			// Final jobs schema: expanded CHECK constraint (all statuses through RETRACTED).
+			// agent_id is nullable so retracted jobs can set it to NULL (FK-safe in SQLite).
 			`CREATE TABLE IF NOT EXISTS jobs (
 				id TEXT PRIMARY KEY,
 				employer_id TEXT NOT NULL REFERENCES users(id),
-				agent_id TEXT NOT NULL REFERENCES agents(id),
+				agent_id TEXT REFERENCES agents(id),
 				status TEXT NOT NULL DEFAULT 'PENDING_ACCEPTANCE' CHECK(status IN (
 					'PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
 					'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
@@ -165,12 +165,58 @@ var migrations = []func(tx *sql.Tx) error{
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			)`,
 			`CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user ON refresh_tokens(user_id)`,
-
 		}
 
 		for _, stmt := range stmts {
 			if _, err := tx.Exec(stmt); err != nil {
 				return fmt.Errorf("statement failed: %w\nSQL: %s", err, stmt)
+			}
+		}
+		return nil
+	},
+
+	// version 1 → 2: make agent_id nullable on the jobs table.
+	// RetractOfferHandler sets agent_id = NULL on retraction; with FK enforcement
+	// enabled (PR #45) an empty-string value violated the agents(id) FK. NULL is
+	// exempt from FK checking in SQLite. SQLite cannot ALTER COLUMN so we rebuild
+	// the table using the rename/copy/drop pattern via complexMigration.
+	func(tx *sql.Tx) error {
+		// complexMigration requires a raw *sql.Conn and manages its own transaction,
+		// so we cannot use the outer tx here. We signal to RunMigrations that this
+		// migration needs the complex path by returning a sentinel — but the simpler
+		// approach is to just run the DDL directly: SQLite allows pragma changes
+		// inside a transaction and the temp-table rename is safe within one tx as
+		// long as FK checks are off.
+		stmts := []string{
+			`PRAGMA foreign_keys = OFF`,
+			`CREATE TABLE IF NOT EXISTS jobs_fk_fix (
+				id TEXT PRIMARY KEY,
+				employer_id TEXT NOT NULL REFERENCES users(id),
+				agent_id TEXT REFERENCES agents(id),
+				status TEXT NOT NULL DEFAULT 'PENDING_ACCEPTANCE' CHECK(status IN (
+					'PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
+					'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
+				)),
+				title TEXT NOT NULL,
+				description TEXT DEFAULT '',
+				total_payout INTEGER NOT NULL,
+				timeline_days INTEGER NOT NULL,
+				stripe_payment_intent TEXT,
+				stripe_checkout_session_id TEXT,
+				delivered_at DATETIME,
+				delivery_notes TEXT,
+				delivery_url TEXT,
+				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+			)`,
+			`INSERT OR IGNORE INTO jobs_fk_fix SELECT * FROM jobs`,
+			`DROP TABLE IF EXISTS jobs`,
+			`ALTER TABLE jobs_fk_fix RENAME TO jobs`,
+			`PRAGMA foreign_keys = ON`,
+		}
+		for _, stmt := range stmts {
+			if _, err := tx.Exec(stmt); err != nil {
+				return fmt.Errorf("migration 1→2 statement failed: %w\nSQL: %s", err, stmt)
 			}
 		}
 		return nil

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -142,9 +142,13 @@ func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 
 func (app *App) scanJob(row interface{ Scan(...interface{}) error }) (Job, error) {
 	var j Job
+	var agentID sql.NullString
 	var stripe sql.NullString
-	err := row.Scan(&j.ID, &j.EmployerID, &j.AgentID, &j.Status, &j.Title, &j.Description,
+	err := row.Scan(&j.ID, &j.EmployerID, &agentID, &j.Status, &j.Title, &j.Description,
 		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt)
+	if agentID.Valid {
+		j.AgentID = agentID.String
+	}
 	if stripe.Valid {
 		j.StripePaymentIntent = stripe.String
 	}
@@ -154,9 +158,13 @@ func (app *App) scanJob(row interface{ Scan(...interface{}) error }) (Job, error
 // scanJobWithName scans a job row that includes an extra agent_name column at the end.
 func (app *App) scanJobWithName(row interface{ Scan(...interface{}) error }) (Job, error) {
 	var j Job
+	var agentID sql.NullString
 	var stripe sql.NullString
-	err := row.Scan(&j.ID, &j.EmployerID, &j.AgentID, &j.Status, &j.Title, &j.Description,
+	err := row.Scan(&j.ID, &j.EmployerID, &agentID, &j.Status, &j.Title, &j.Description,
 		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt, &j.AgentName)
+	if agentID.Valid {
+		j.AgentID = agentID.String
+	}
 	if stripe.Valid {
 		j.StripePaymentIntent = stripe.String
 	}
@@ -1145,7 +1153,7 @@ func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
 	jobID := chi.URLParam(r, "id")
 
 	result, err := app.DB.Exec(
-		`UPDATE jobs SET status = 'RETRACTED', agent_id = '', updated_at = CURRENT_TIMESTAMP
+		`UPDATE jobs SET status = 'RETRACTED', agent_id = NULL, updated_at = CURRENT_TIMESTAMP
 		 WHERE id = ? AND employer_id = ? AND status = 'PENDING_ACCEPTANCE'`,
 		jobID, employerID,
 	)


### PR DESCRIPTION
Fixes #42. Enabling foreign_keys pragma surfaced a pre-existing FK violation in RetractOfferHandler — it set agent_id to empty string which is not a valid agents.id. Changed to NULL (exempt from FK checking) and made agent_id nullable in schema.

## Changes

- `backend/db.go`: Removed `NOT NULL` from `agent_id` in all three jobs table schema definitions (original schema, M2 migration `jobs_new`, M3 migration `jobs_retracted`)
- `backend/jobs.go`: Changed `agent_id = ''` to `agent_id = NULL` in `RetractOfferHandler`
- `backend/jobs.go`: Updated `scanJob` and `scanJobWithName` to scan `agent_id` into `sql.NullString` since the column is now nullable