### PR TITLE
feat: allow employers to retract offers up until contract is final (Issue #35)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -98,6 +98,7 @@ var migrations = []func(tx *sql.Tx) error{
 				description TEXT DEFAULT '',
 				total_payout INTEGER NOT NULL,
 				timeline_days INTEGER NOT NULL,
+				sow_link TEXT DEFAULT '',
 				stripe_payment_intent TEXT,
 				stripe_checkout_session_id TEXT,
 				delivered_at DATETIME,
@@ -113,6 +114,7 @@ var migrations = []func(tx *sql.Tx) error{
 				title TEXT NOT NULL,
 				amount INTEGER NOT NULL,
 				order_index INTEGER NOT NULL,
+				deliverables TEXT NOT NULL DEFAULT '',
 				status TEXT NOT NULL DEFAULT 'PENDING' CHECK(status IN ('PENDING','REVIEW_REQUESTED','APPROVED','PAID')),
 				proof_of_work_url TEXT DEFAULT '',
 				proof_of_work_notes TEXT DEFAULT '',
@@ -131,9 +133,8 @@ var migrations = []func(tx *sql.Tx) error{
 			`CREATE TABLE IF NOT EXISTS sow (
 				id TEXT PRIMARY KEY,
 				job_id TEXT NOT NULL REFERENCES jobs(id),
-				scope TEXT NOT NULL DEFAULT '',
-				deliverables TEXT NOT NULL DEFAULT '',
-				employer_provides TEXT NOT NULL DEFAULT '',
+				detailed_spec TEXT NOT NULL DEFAULT '',
+				work_process TEXT NOT NULL DEFAULT '',
 				price_cents INTEGER NOT NULL DEFAULT 0,
 				timeline_days INTEGER NOT NULL DEFAULT 0,
 				agent_accepted INTEGER NOT NULL DEFAULT 0,
@@ -202,6 +203,50 @@ var migrations = []func(tx *sql.Tx) error{
 	// FK constraint errors. complexMigration() pins a raw *sql.Conn and disables
 	// FK enforcement before beginning the transaction.
 	func(tx *sql.Tx) error { return nil },
+
+	// version 3 → 4: Issue #44 SoW redesign — replace scope/deliverables/employer_provides
+	// with detailed_spec and work_process in the sow table.
+	// Fresh databases created after migration 0 was updated already have detailed_spec
+	// and work_process, so we handle the duplicate-column case gracefully.
+	func(tx *sql.Tx) error {
+		// Add detailed_spec (replaces scope)
+		if _, err := tx.Exec(`ALTER TABLE sow ADD COLUMN detailed_spec TEXT NOT NULL DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("add detailed_spec to sow: %w", err)
+			}
+		}
+		// Add work_process (replaces deliverables + employer_provides)
+		if _, err := tx.Exec(`ALTER TABLE sow ADD COLUMN work_process TEXT NOT NULL DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("add work_process to sow: %w", err)
+			}
+		}
+		// Copy existing data: scope → detailed_spec, deliverables + employer_provides → work_process
+		if _, err := tx.Exec(`UPDATE sow SET detailed_spec = COALESCE(scope, ''), work_process = COALESCE(deliverables, '') WHERE detailed_spec = ''`); err != nil {
+			return fmt.Errorf("migrate sow data: %w", err)
+		}
+		return nil
+	},
+
+	// version 4 → 5: Issue #44 — add sow_link column to jobs table (optional URL).
+	func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`ALTER TABLE jobs ADD COLUMN sow_link TEXT DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("add sow_link to jobs: %w", err)
+			}
+		}
+		return nil
+	},
+
+	// version 5 → 6: Issue #44 — add deliverables column to milestones table.
+	func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`ALTER TABLE milestones ADD COLUMN deliverables TEXT NOT NULL DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("add deliverables to milestones: %w", err)
+			}
+		}
+		return nil
+	},
 }
 
 // rawMigrations holds migrations that need a raw *sql.DB (and therefore a raw
@@ -269,6 +314,7 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 					description TEXT DEFAULT '',
 					total_payout INTEGER NOT NULL,
 					timeline_days INTEGER NOT NULL,
+					sow_link TEXT DEFAULT '',
 					stripe_payment_intent TEXT,
 					stripe_checkout_session_id TEXT,
 					delivered_at DATETIME,
@@ -278,7 +324,7 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 				)`,
 				`INSERT INTO jobs_new SELECT id, employer_id, NULLIF(agent_id,''), status, title, description,
-				 total_payout, timeline_days, stripe_payment_intent, stripe_checkout_session_id,
+				 total_payout, timeline_days, '' AS sow_link, stripe_payment_intent, stripe_checkout_session_id,
 				 delivered_at, delivery_notes, delivery_url, created_at, updated_at FROM jobs`,
 				`DROP TABLE jobs`,
 				`ALTER TABLE jobs_new RENAME TO jobs`,

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	stripe "github.com/stripe/stripe-go/v82"
+	stripesession "github.com/stripe/stripe-go/v82/checkout/session"
 	"github.com/stripe/stripe-go/v82/paymentintent"
 )
 
@@ -30,6 +31,7 @@ type Milestone struct {
 	Title            string      `json:"title"`
 	Amount           int64       `json:"amount"`
 	OrderIndex       int         `json:"order_index"`
+	Deliverables     string      `json:"deliverables"`
 	Status           string      `json:"status"`
 	ProofOfWorkURL   string      `json:"proof_of_work_url"`
 	ProofOfWorkNotes string      `json:"proof_of_work_notes"`
@@ -48,6 +50,7 @@ type Job struct {
 	Description         string      `json:"description"`
 	TotalPayout         int64       `json:"total_payout"`
 	TimelineDays        int         `json:"timeline_days"`
+	SowLink             string      `json:"sow_link,omitempty"`
 	StripePaymentIntent string      `json:"stripe_payment_intent,omitempty"`
 	CreatedAt           time.Time   `json:"created_at"`
 	UpdatedAt           time.Time   `json:"updated_at"`
@@ -58,9 +61,10 @@ type Job struct {
 // --- Request types ---
 
 type MilestoneInput struct {
-	Title    string   `json:"title"`
-	Amount   int64    `json:"amount"`
-	Criteria []string `json:"criteria"`
+	Title        string   `json:"title"`
+	Amount       int64    `json:"amount"`
+	Deliverables string   `json:"deliverables"`
+	Criteria     []string `json:"criteria"`
 }
 
 type HireRequest struct {
@@ -69,6 +73,7 @@ type HireRequest struct {
 	Description  string           `json:"description"`
 	TotalPayout  int64            `json:"total_payout"`
 	TimelineDays int              `json:"timeline_days"`
+	SowLink      string           `json:"sow_link"`
 	Milestones   []MilestoneInput `json:"milestones"`
 }
 
@@ -111,7 +116,7 @@ func (app *App) loadCriteriaForMilestone(milestoneID string) ([]Criterion, error
 
 func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 	rows, err := app.DB.Query(
-		`SELECT id, job_id, title, amount, order_index, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
+		`SELECT id, job_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
 		 FROM milestones WHERE job_id = ? ORDER BY order_index`,
 		jobID,
 	)
@@ -123,7 +128,7 @@ func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 	var milestones []Milestone
 	for rows.Next() {
 		var m Milestone
-		if err := rows.Scan(&m.ID, &m.JobID, &m.Title, &m.Amount, &m.OrderIndex, &m.Status,
+		if err := rows.Scan(&m.ID, &m.JobID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
 			&m.ProofOfWorkURL, &m.ProofOfWorkNotes, &m.CreatedAt, &m.UpdatedAt); err != nil {
 			return nil, err
 		}
@@ -142,14 +147,17 @@ func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 
 func (app *App) scanJob(row interface{ Scan(...interface{}) error }) (Job, error) {
 	var j Job
-	var agentID, stripe sql.NullString
+	var agentID, stripe, sowLink sql.NullString
 	err := row.Scan(&j.ID, &j.EmployerID, &agentID, &j.Status, &j.Title, &j.Description,
-		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt)
+		&j.TotalPayout, &j.TimelineDays, &sowLink, &stripe, &j.CreatedAt, &j.UpdatedAt)
 	if agentID.Valid {
 		j.AgentID = agentID.String
 	}
 	if stripe.Valid {
 		j.StripePaymentIntent = stripe.String
+	}
+	if sowLink.Valid {
+		j.SowLink = sowLink.String
 	}
 	return j, err
 }
@@ -157,14 +165,17 @@ func (app *App) scanJob(row interface{ Scan(...interface{}) error }) (Job, error
 // scanJobWithName scans a job row that includes an extra agent_name column at the end.
 func (app *App) scanJobWithName(row interface{ Scan(...interface{}) error }) (Job, error) {
 	var j Job
-	var agentID, stripe sql.NullString
+	var agentID, stripe, sowLink sql.NullString
 	err := row.Scan(&j.ID, &j.EmployerID, &agentID, &j.Status, &j.Title, &j.Description,
-		&j.TotalPayout, &j.TimelineDays, &stripe, &j.CreatedAt, &j.UpdatedAt, &j.AgentName)
+		&j.TotalPayout, &j.TimelineDays, &sowLink, &stripe, &j.CreatedAt, &j.UpdatedAt, &j.AgentName)
 	if agentID.Valid {
 		j.AgentID = agentID.String
 	}
 	if stripe.Valid {
 		j.StripePaymentIntent = stripe.String
+	}
+	if sowLink.Valid {
+		j.SowLink = sowLink.String
 	}
 	return j, err
 }
@@ -229,9 +240,9 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 
 	jobID := uuid.New().String()
 	_, err = tx.Exec(
-		`INSERT INTO jobs (id, employer_id, agent_id, title, description, total_payout, timeline_days)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		jobID, employerID, req.AgentID, req.Title, req.Description, req.TotalPayout, req.TimelineDays,
+		`INSERT INTO jobs (id, employer_id, agent_id, title, description, total_payout, timeline_days, sow_link)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		jobID, employerID, req.AgentID, req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink,
 	)
 	if err != nil {
 		log.Error("job creation failed: insert error", "employer_id", employerID, "agent_id", req.AgentID, "error", err)
@@ -242,8 +253,8 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 	for i, ms := range req.Milestones {
 		msID := uuid.New().String()
 		_, err = tx.Exec(
-			`INSERT INTO milestones (id, job_id, title, amount, order_index) VALUES (?, ?, ?, ?, ?)`,
-			msID, jobID, ms.Title, ms.Amount, i,
+			`INSERT INTO milestones (id, job_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
+			msID, jobID, ms.Title, ms.Amount, i, ms.Deliverables,
 		)
 		if err != nil {
 			log.Error("job creation failed: milestone insert error", "job_id", jobID, "milestone_index", i, "error", err)
@@ -361,8 +372,8 @@ func (app *App) UpdateJobHandler(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback()
 
 	_, err = tx.Exec(
-		`UPDATE jobs SET title = ?, description = ?, total_payout = ?, timeline_days = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
-		req.Title, req.Description, req.TotalPayout, req.TimelineDays, jobID,
+		`UPDATE jobs SET title = ?, description = ?, total_payout = ?, timeline_days = ?, sow_link = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink, jobID,
 	)
 	if err != nil {
 		log.Error("update job: update error", "job_id", jobID, "error", err)
@@ -387,8 +398,8 @@ func (app *App) UpdateJobHandler(w http.ResponseWriter, r *http.Request) {
 	for i, ms := range req.Milestones {
 		msID := uuid.New().String()
 		_, err = tx.Exec(
-			`INSERT INTO milestones (id, job_id, title, amount, order_index) VALUES (?, ?, ?, ?, ?)`,
-			msID, jobID, ms.Title, ms.Amount, i,
+			`INSERT INTO milestones (id, job_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
+			msID, jobID, ms.Title, ms.Amount, i, ms.Deliverables,
 		)
 		if err != nil {
 			log.Error("update job: milestone insert error", "job_id", jobID, "milestone_index", i, "error", err)
@@ -526,7 +537,7 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 	if role == "EMPLOYER" {
 		// JOIN agents so we can return the agent name alongside agent_id
 		rows, err = app.DB.Query(
-			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
+			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.sow_link, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
 			 FROM jobs j
 			 LEFT JOIN agents a ON j.agent_id = a.id
 			 WHERE j.employer_id = ?
@@ -536,7 +547,7 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// AGENT_HANDLER: list jobs for any of their agents
 		rows, err = app.DB.Query(
-			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
+			`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.sow_link, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
 			 FROM jobs j
 			 JOIN agents a ON j.agent_id = a.id
 			 WHERE a.handler_id = ?
@@ -567,7 +578,7 @@ func (app *App) ListJobsHandler(w http.ResponseWriter, r *http.Request) {
 
 func (app *App) getJobDetail(jobID string) (Job, error) {
 	row := app.DB.QueryRow(
-		`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
+		`SELECT j.id, j.employer_id, j.agent_id, j.status, j.title, j.description, j.total_payout, j.timeline_days, j.sow_link, j.stripe_payment_intent, j.created_at, j.updated_at, COALESCE(a.name, '')
 		 FROM jobs j
 		 LEFT JOIN agents a ON j.agent_id = a.id
 		 WHERE j.id = ?`,
@@ -1134,8 +1145,14 @@ func (app *App) RequestRevisionHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(j)
 }
 
-// RetractOfferHandler allows an employer to retract a pending job offer.
-// The offer must be in PENDING_ACCEPTANCE status (i.e. sent to an agent but not yet accepted).
+// RetractOfferHandler allows an employer to retract a job offer before both parties have
+// committed via payment. Retraction is permitted while the job is in any of:
+//   - PENDING_ACCEPTANCE  — agent has not yet accepted
+//   - SOW_NEGOTIATION     — scope is being negotiated
+//   - AWAITING_PAYMENT    — both parties agreed but employer has not paid
+//
+// Once payment succeeds (status moves to IN_PROGRESS) the contract is final and cannot
+// be retracted.
 // POST /api/ui/jobs/{id}/retract
 func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
 	log := slog.With("request_id", requestID(r.Context()), "handler", "retract_offer")
@@ -1150,9 +1167,62 @@ func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
 	employerID, _ := r.Context().Value(contextKeyUserID).(string)
 	jobID := chi.URLParam(r, "id")
 
+	// Fetch current job status and any outstanding Stripe checkout session ID.
+	var currentStatus string
+	var stripeCheckoutSessionID sql.NullString
+	err := app.DB.QueryRow(
+		`SELECT status, stripe_checkout_session_id FROM jobs WHERE id = ? AND employer_id = ?`,
+		jobID, employerID,
+	).Scan(&currentStatus, &stripeCheckoutSessionID)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found or not owned by you")
+		return
+	}
+	if err != nil {
+		log.Error("retract offer: db error fetching job", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	// Only allow retraction before the contract is final (i.e. before payment).
+	retractableStatuses := map[string]bool{
+		"PENDING_ACCEPTANCE": true,
+		"SOW_NEGOTIATION":    true,
+		"AWAITING_PAYMENT":   true,
+	}
+	if !retractableStatuses[currentStatus] {
+		writeError(w, http.StatusConflict, "cannot retract an offer once the contract is final (job is "+currentStatus+")")
+		return
+	}
+
+	// If the job reached AWAITING_PAYMENT, an open Stripe Checkout Session may exist.
+	// Attempt to expire it so the employer is not charged later. We treat a Stripe
+	// failure as a warning — the DB update still proceeds.
+	if stripeCheckoutSessionID.Valid && stripeCheckoutSessionID.String != "" {
+		stripe.Key = app.Config.StripeSecretKey
+		_, stripeErr := stripesession.Expire(stripeCheckoutSessionID.String, &stripe.CheckoutSessionExpireParams{})
+		if stripeErr != nil {
+			log.Warn("retract offer: could not expire stripe checkout session",
+				"job_id", jobID,
+				"session_id", stripeCheckoutSessionID.String,
+				"error", stripeErr,
+			)
+		} else {
+			log.Info("retract offer: stripe checkout session expired",
+				"job_id", jobID,
+				"session_id", stripeCheckoutSessionID.String,
+			)
+		}
+	}
+
 	result, err := app.DB.Exec(
-		`UPDATE jobs SET status = 'RETRACTED', agent_id = NULL, updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND employer_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		`UPDATE jobs
+		    SET status = 'RETRACTED',
+		        agent_id = NULL,
+		        stripe_checkout_session_id = NULL,
+		        updated_at = CURRENT_TIMESTAMP
+		  WHERE id = ? AND employer_id = ?
+		    AND status IN ('PENDING_ACCEPTANCE', 'SOW_NEGOTIATION', 'AWAITING_PAYMENT')`,
 		jobID, employerID,
 	)
 	if err != nil {
@@ -1163,11 +1233,11 @@ func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
 
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
-		writeError(w, http.StatusNotFound, "job not found, not owned by you, or not in PENDING_ACCEPTANCE status")
+		writeError(w, http.StatusConflict, "job could not be retracted — it may have been updated concurrently")
 		return
 	}
 
-	log.Info("offer retracted", "job_id", jobID, "employer_id", employerID)
+	log.Info("offer retracted", "job_id", jobID, "employer_id", employerID, "previous_status", currentStatus)
 
 	j, err := app.getJobDetail(jobID)
 	if err != nil {

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -267,10 +267,10 @@ func TestRetractOffer(t *testing.T) {
 		t.Errorf("expected agent_id to be cleared, got %q", retracted.AgentID)
 	}
 
-	// Retracting again should fail (no longer PENDING_ACCEPTANCE)
+	// Retracting again should fail — status is now RETRACTED (not a retractable status)
 	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
-	if rr.Code != http.StatusNotFound {
-		t.Errorf("double-retract: expected 404, got %d", rr.Code)
+	if rr.Code != http.StatusConflict {
+		t.Errorf("double-retract: expected 409, got %d", rr.Code)
 	}
 }
 
@@ -299,7 +299,9 @@ func TestRetractOfferWrongEmployer(t *testing.T) {
 	}
 }
 
-func TestRetractOfferNonPending(t *testing.T) {
+// TestRetractOfferDuringSowNegotiation verifies that an employer can retract while the
+// job is in SOW_NEGOTIATION (agent has accepted but scope is still being negotiated).
+func TestRetractOfferDuringSowNegotiation(t *testing.T) {
 	t.Parallel()
 	app := setupTestApp(t)
 	router := NewRouter(app)
@@ -307,18 +309,70 @@ func TestRetractOfferNonPending(t *testing.T) {
 	employerID, _, agentID, apiKey := setupJobFixtures(t, app)
 	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
 
-	// Create and accept a job (moves to SOW_NEGOTIATION)
+	// Create a job and have the agent accept it (moves to SOW_NEGOTIATION)
 	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
-		HireRequest{AgentID: agentID, Title: "Accepted job", TotalPayout: 200, TimelineDays: 2},
+		HireRequest{AgentID: agentID, Title: "Sow negotiation job", TotalPayout: 300, TimelineDays: 5},
 		employerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("hire: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
 	var job Job
 	json.Unmarshal(rr.Body.Bytes(), &job)
 
 	doRequest(t, router, http.MethodPost, "/api/v1/jobs/"+job.ID+"/accept", nil, apiKey)
 
-	// Employer tries to retract after acceptance
+	// Verify job is now in SOW_NEGOTIATION
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+job.ID, nil, employerToken)
+	var updated Job
+	json.Unmarshal(rr.Body.Bytes(), &updated)
+	if updated.Status != "SOW_NEGOTIATION" {
+		t.Fatalf("expected SOW_NEGOTIATION, got %q", updated.Status)
+	}
+
+	// Employer retracts during negotiation — should succeed
 	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
-	if rr.Code != http.StatusNotFound {
-		t.Errorf("non-pending retract: expected 404, got %d: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("retract during SOW_NEGOTIATION: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var retracted Job
+	json.Unmarshal(rr.Body.Bytes(), &retracted)
+	if retracted.Status != "RETRACTED" {
+		t.Errorf("expected RETRACTED, got %q", retracted.Status)
+	}
+	if retracted.AgentID != "" {
+		t.Errorf("expected agent_id cleared, got %q", retracted.AgentID)
+	}
+}
+
+// TestRetractOfferFinalContract verifies that retraction is blocked once the contract is
+// final (IN_PROGRESS and beyond — i.e. after payment has been captured).
+func TestRetractOfferFinalContract(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, _, agentID, _ := setupJobFixtures(t, app)
+	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	// Create a job
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
+		HireRequest{AgentID: agentID, Title: "Final contract job", TotalPayout: 200, TimelineDays: 2},
+		employerToken)
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+
+	// Force job directly to IN_PROGRESS (simulating completed payment)
+	_, err := app.DB.Exec(
+		`UPDATE jobs SET status = 'IN_PROGRESS', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+		job.ID,
+	)
+	if err != nil {
+		t.Fatalf("failed to set job to IN_PROGRESS: %v", err)
+	}
+
+	// Employer tries to retract a final contract — should be blocked
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
+	if rr.Code != http.StatusConflict {
+		t.Errorf("final contract retract: expected 409, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/backend/sow.go
+++ b/backend/sow.go
@@ -15,9 +15,8 @@ import (
 type SOW struct {
 	ID               string `json:"id"`
 	JobID            string `json:"job_id"`
-	Scope            string `json:"scope"`             // detailed description of the SoW
-	Deliverables     string `json:"deliverables"`      // what the agent delivers
-	EmployerProvides string `json:"employer_provides"` // what the employer provides
+	DetailedSpec     string `json:"detailed_spec"` // detailed specification of work
+	WorkProcess      string `json:"work_process"`  // communication/process description
 	PriceCents       int    `json:"price_cents"`
 	TimelineDays     int    `json:"timeline_days"`
 	AgentAccepted    bool   `json:"agent_accepted"`
@@ -30,11 +29,10 @@ type SOW struct {
 // --- Request types ---
 
 type SOWRequest struct {
-	Scope            string `json:"scope"`
-	Deliverables     string `json:"deliverables"`
-	EmployerProvides string `json:"employer_provides"`
-	PriceCents       int    `json:"price_cents"`
-	TimelineDays     int    `json:"timeline_days"`
+	DetailedSpec string `json:"detailed_spec"`
+	WorkProcess  string `json:"work_process"`
+	PriceCents   int    `json:"price_cents"`
+	TimelineDays int    `json:"timeline_days"`
 }
 
 // --- Helpers ---
@@ -44,10 +42,10 @@ func (app *App) getSOWByJobID(jobID string) (SOW, error) {
 	var agentAccepted, employerAccepted int
 	var lastEditedBy sql.NullString
 	err := app.DB.QueryRow(
-		`SELECT id, job_id, scope, deliverables, employer_provides, price_cents, timeline_days, agent_accepted, employer_accepted, last_edited_by, created_at, updated_at
+		`SELECT id, job_id, detailed_spec, work_process, price_cents, timeline_days, agent_accepted, employer_accepted, last_edited_by, created_at, updated_at
 		 FROM sow WHERE job_id = ?`,
 		jobID,
-	).Scan(&s.ID, &s.JobID, &s.Scope, &s.Deliverables, &s.EmployerProvides, &s.PriceCents, &s.TimelineDays,
+	).Scan(&s.ID, &s.JobID, &s.DetailedSpec, &s.WorkProcess, &s.PriceCents, &s.TimelineDays,
 		&agentAccepted, &employerAccepted, &lastEditedBy, &s.CreatedAt, &s.UpdatedAt)
 	if err != nil {
 		return s, err
@@ -127,9 +125,9 @@ func (app *App) CreateOrUpdateSOW(w http.ResponseWriter, r *http.Request) {
 		// Create new SOW
 		sowID := uuid.New().String()
 		_, err = app.DB.Exec(
-			`INSERT INTO sow (id, job_id, scope, deliverables, employer_provides, price_cents, timeline_days, agent_accepted, employer_accepted, last_edited_by)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, ?)`,
-			sowID, jobID, req.Scope, req.Deliverables, req.EmployerProvides, req.PriceCents, req.TimelineDays, userID,
+			`INSERT INTO sow (id, job_id, detailed_spec, work_process, price_cents, timeline_days, agent_accepted, employer_accepted, last_edited_by)
+			 VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?)`,
+			sowID, jobID, req.DetailedSpec, req.WorkProcess, req.PriceCents, req.TimelineDays, userID,
 		)
 		if err != nil {
 			log.Error("sow create: insert error", "job_id", jobID, "error", err)
@@ -144,10 +142,10 @@ func (app *App) CreateOrUpdateSOW(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Update existing SOW — reset both acceptance flags
 		_, err = app.DB.Exec(
-			`UPDATE sow SET scope = ?, deliverables = ?, employer_provides = ?, price_cents = ?, timeline_days = ?,
+			`UPDATE sow SET detailed_spec = ?, work_process = ?, price_cents = ?, timeline_days = ?,
 			 agent_accepted = 0, employer_accepted = 0, last_edited_by = ?, updated_at = CURRENT_TIMESTAMP
 			 WHERE job_id = ?`,
-			req.Scope, req.Deliverables, req.EmployerProvides, req.PriceCents, req.TimelineDays, userID, jobID,
+			req.DetailedSpec, req.WorkProcess, req.PriceCents, req.TimelineDays, userID, jobID,
 		)
 		if err != nil {
 			log.Error("sow update: exec error", "job_id", jobID, "error", err)

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -207,7 +207,7 @@
 											Submit to Agent
 										</a>
 									{/if}
-									{#if job.status === 'PENDING_ACCEPTANCE'}
+									{#if ['PENDING_ACCEPTANCE', 'SOW_NEGOTIATION', 'AWAITING_PAYMENT'].includes(job.status)}
 										<button
 											class="btn btn-secondary"
 											style="font-size: 0.8rem; padding: 0.25rem 0.75rem; white-space: nowrap; color: #991b1b; border-color: #fca5a5;"

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -245,7 +245,7 @@
 			{#if isEmployer && (!job.agent_id || job.agent_id === '')}
 				<a href="/jobs/{jobId}/edit" class="btn btn-secondary" style="white-space: nowrap;">Edit Brief</a>
 			{/if}
-			{#if isEmployer && job.status === 'PENDING_ACCEPTANCE'}
+			{#if isEmployer && ['PENDING_ACCEPTANCE', 'SOW_NEGOTIATION', 'AWAITING_PAYMENT'].includes(job.status)}
 				<div>
 					{#if retractError}
 						<div class="alert alert-error" style="margin-bottom: 0.5rem;">{retractError}</div>

--- a/frontend/src/routes/jobs/new/+page.svelte
+++ b/frontend/src/routes/jobs/new/+page.svelte
@@ -31,17 +31,11 @@
 		};
 	}
 
-	interface Milestone {
-		title: string;
-		payout: number;
-		criteria: string[];
-	}
-
 	let title = $state('');
 	let description = $state('');
 	let payout = $state(0);
 	let timeline = $state('');
-	let milestones: Milestone[] = $state([{ title: '', payout: 0, criteria: [''] }]);
+	let sowLink = $state('');
 
 	let submitting = $state(false);
 	let error = $state('');
@@ -59,36 +53,6 @@
 		}
 	});
 
-	function addMilestone() {
-		milestones = [...milestones, { title: '', payout: 0, criteria: [''] }];
-	}
-
-	function removeMilestone(i: number) {
-		milestones = milestones.filter((_, idx) => idx !== i);
-	}
-
-	function addCriteria(milestoneIdx: number) {
-		milestones = milestones.map((m, i) =>
-			i === milestoneIdx ? { ...m, criteria: [...m.criteria, ''] } : m
-		);
-	}
-
-	function removeCriteria(milestoneIdx: number, criteriaIdx: number) {
-		milestones = milestones.map((m, i) =>
-			i === milestoneIdx
-				? { ...m, criteria: m.criteria.filter((_, ci) => ci !== criteriaIdx) }
-				: m
-		);
-	}
-
-	function updateCriteria(milestoneIdx: number, criteriaIdx: number, value: string) {
-		milestones = milestones.map((m, i) =>
-			i === milestoneIdx
-				? { ...m, criteria: m.criteria.map((c, ci) => (ci === criteriaIdx ? value : c)) }
-				: m
-		);
-	}
-
 	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault();
 		error = '';
@@ -100,11 +64,8 @@
 				description,
 				total_payout: Math.round(Number(payout)),
 				timeline_days: Math.round(Number(timeline)) || 0,
-				milestones: milestones.map((m) => ({
-					title: m.title,
-					amount: Math.round(Number(m.payout || 0)),
-					criteria: m.criteria.filter((c) => c.trim())
-				}))
+				sow_link: sowLink,
+				milestones: []
 			};
 			const res = await apiFetch('/api/ui/jobs/hire', {
 				method: 'POST',
@@ -134,7 +95,7 @@
 
 	<div class="page-header">
 		<h1>Enter a Job Brief</h1>
-		<p>Describe the work, set milestones, and define success criteria. You can assign an agent later.</p>
+		<p>Describe the work at a high level. You can add a detailed Statement of Work later, together with the Agent.</p>
 	</div>
 
 	{#if error}
@@ -149,8 +110,8 @@
 				<input id="title" type="text" bind:value={title} required placeholder="e.g. Build a landing page, Research competitors" />
 			</div>
 			<div class="form-group">
-				<label for="description">Description</label>
-				<textarea id="description" bind:value={description} required placeholder="Describe the task in detail. What do you need done? What does success look like?" rows={MIN_ROWS} use:steppedResize></textarea>
+				<label for="description">Brief Description</label>
+				<textarea id="description" bind:value={description} required placeholder="Briefly describe the task. What do you need done?" rows={MIN_ROWS} use:steppedResize></textarea>
 			</div>
 			<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
 				<div class="form-group">
@@ -165,58 +126,14 @@
 		</div>
 
 		<div class="card" style="margin-bottom: 1.5rem;">
-			<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-				<h2 style="margin: 0; font-size: 1.1rem;">Milestones</h2>
-				<button type="button" class="btn btn-secondary" onclick={addMilestone} style="font-size: 0.85rem; padding: 0.35rem 0.9rem;">
-					+ Add milestone
-				</button>
+			<h2 style="margin: 0 0 0.5rem; font-size: 1.1rem;">Statement of Work</h2>
+			<p style="color: #666; font-size: 0.9rem; margin: 0 0 1rem;">
+				The Statement of Work (SoW) is optional at this stage. After a Job is offered, the Agent can help you fill out the SoW.
+			</p>
+			<div class="form-group" style="margin-bottom: 0;">
+				<label for="sow-link">Link to SoW (optional)</label>
+				<input id="sow-link" type="url" bind:value={sowLink} placeholder="https://docs.example.com/sow" />
 			</div>
-
-			{#each milestones as milestone, i}
-				<div class="milestone-row">
-					<div class="milestone-header">
-						<strong style="font-size: 0.9rem;">Milestone {i + 1}</strong>
-						{#if milestones.length > 1}
-							<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
-								Remove
-							</button>
-						{/if}
-					</div>
-					<div style="display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; align-items: start;">
-						<div class="form-group" style="margin-bottom: 0.5rem;">
-							<label for="m-title-{i}">Title</label>
-							<input id="m-title-{i}" type="text" bind:value={milestone.title} required placeholder="Milestone title" />
-						</div>
-						<div class="form-group" style="margin-bottom: 0.5rem;">
-							<label for="m-payout-{i}">Payout (USD)</label>
-							<input id="m-payout-{i}" type="number" bind:value={milestone.payout} min="0" step="0.01" placeholder="0.00" style="width: 130px;" />
-						</div>
-					</div>
-					<div>
-						<p style="font-size: 0.9rem; font-weight: 500; color: #333; margin: 0 0 0.5rem;">
-							Acceptance criteria
-						</p>
-						{#each milestone.criteria as criterion, ci}
-							<div style="display: flex; gap: 0.5rem; margin-bottom: 0.4rem; align-items: flex-start;">
-								<textarea
-									value={criterion}
-									oninput={(e) => updateCriteria(i, ci, (e.target as HTMLTextAreaElement).value)}
-									placeholder="e.g. All tests pass, Page loads in under 2s"
-									rows={MIN_ROWS}
-									use:steppedResize
-									style="flex: 1; padding: 0.4rem 0.6rem; border: 1px solid #ced4da; border-radius: 6px; font-size: 0.9rem; resize: none;"
-								></textarea>
-								{#if milestone.criteria.length > 1}
-									<button type="button" onclick={() => removeCriteria(i, ci)} style="background: none; border: none; color: #dc3545; cursor: pointer; font-size: 1.1rem; padding: 0.3rem 0.25rem;" title="Remove">×</button>
-								{/if}
-							</div>
-						{/each}
-						<button type="button" onclick={() => addCriteria(i)} style="background: none; border: none; color: #0066cc; cursor: pointer; font-size: 0.85rem; padding: 0.1rem 0; margin-top: 0.2rem;">
-							+ Add criterion
-						</button>
-					</div>
-				</div>
-			{/each}
 		</div>
 
 		<div style="display: flex; gap: 1rem;">


### PR DESCRIPTION
## Summary

Closes #35

Employers can now retract a job offer at any point before the contract is final (i.e. before payment). Previously, retraction was only possible while the job was in `PENDING_ACCEPTANCE` status.

**Retractable statuses (pre-contract):**
- `PENDING_ACCEPTANCE` — agent has not yet accepted the offer
- `SOW_NEGOTIATION` — both parties are negotiating the scope
- `AWAITING_PAYMENT` — both parties agreed but employer has not paid yet

**Final / non-retractable (post-payment):**
- `IN_PROGRESS`, `DELIVERED`, `COMPLETED` — contract is binding

## Changes

### Backend (`backend/jobs.go`)
- `RetractOfferHandler` now accepts retraction from all three pre-payment statuses
- If a Stripe Checkout Session exists (job in `AWAITING_PAYMENT`), it is expired via the Stripe API on retraction so the employer cannot be charged after the fact
- `stripe_checkout_session_id` is cleared in the DB on retraction
- Returns `HTTP 409 Conflict` (instead of 404) when retraction is blocked due to status, with a clear error message

### Frontend
- `jobs/[job_id]/+page.svelte` — Retract Offer button shown for all three retractable statuses
- `dashboard/employer/+page.svelte` — Same

### Tests (`backend/jobs_test.go`)
- Added `TestRetractOfferDuringSowNegotiation` — verifies retraction succeeds from `SOW_NEGOTIATION`
- Added `TestRetractOfferFinalContract` — verifies retraction is blocked once `IN_PROGRESS`
- Updated double-retract assertion from `404` to `409`

### Pre-existing uncommitted changes (included in this PR)
These were present in the working tree and are related to the SOW redesign work:
- `db.go`: migration v3→v4 — `sow_link` on jobs, `deliverables` on milestones, SOW schema redesign (`detailed_spec` / `work_process`)
- `sow.go`: updated for new SOW schema fields
- `jobs/new/+page.svelte`: simplified new job form

## Test plan

- [ ] Employer can retract a `PENDING_ACCEPTANCE` offer (existing behavior, still works)
- [ ] Employer can retract during `SOW_NEGOTIATION` — job becomes `RETRACTED`, agent cleared
- [ ] Employer can retract during `AWAITING_PAYMENT` — Stripe session is expired, job becomes `RETRACTED`
- [ ] Employer cannot retract once job is `IN_PROGRESS` — returns 409 with clear error
- [ ] Retract button visible for all three retractable statuses in the UI
- [ ] Retract button not visible for `IN_PROGRESS` / `COMPLETED` / `DELIVERED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)