### PR TITLE
fix: Job Brief creation FK constraint (Issue #56)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -245,10 +245,14 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 	defer tx.Rollback()
 
 	jobID := uuid.New().String()
+	var agentIDParam interface{}
+	if req.AgentID != "" {
+		agentIDParam = req.AgentID
+	}
 	_, err = tx.Exec(
 		`INSERT INTO jobs (id, employer_id, agent_id, title, description, total_payout, timeline_days, sow_link)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		jobID, employerID, req.AgentID, req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink,
+		jobID, employerID, agentIDParam, req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink,
 	)
 	if err != nil {
 		log.Error("job creation failed: insert error", "employer_id", employerID, "agent_id", req.AgentID, "error", err)

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -61,6 +61,41 @@ func TestHireAgent(t *testing.T) {
 	}
 }
 
+// TestHireAgentNoAgentID verifies that a job can be created without an agent_id (i.e. agent_id
+// is omitted or empty). This was previously broken because an empty string was passed as the
+// agent_id FK value, causing a FOREIGN KEY constraint failure (SQLite error 787).
+func TestHireAgentNoAgentID(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, _ := createVerifiedTestUser(t, app, "EMPLOYER")
+	token := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	body := HireRequest{
+		// AgentID intentionally omitted (empty string)
+		Title:        "Draft job without agent",
+		Description:  "No agent assigned yet",
+		TotalPayout:  1000,
+		TimelineDays: 5,
+	}
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire", body, token)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 for job without agent_id, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var job Job
+	if err := json.Unmarshal(rr.Body.Bytes(), &job); err != nil {
+		t.Fatalf("decode job: %v", err)
+	}
+	if job.ID == "" {
+		t.Error("expected job ID")
+	}
+	if job.AgentID != "" {
+		t.Errorf("expected empty agent_id, got %q", job.AgentID)
+	}
+}
+
 func TestHireAgentUnverifiedEmail(t *testing.T) {
 	t.Parallel()
 	app := setupTestApp(t)


### PR DESCRIPTION
## Root Cause

When an employer submits a Job Brief without selecting an agent, the frontend sends `agent_id` as an empty string `""`. In `HireAgentHandler`, this empty string was passed directly as the SQL parameter for `jobs.agent_id`.

The `jobs.agent_id` column is defined as `TEXT REFERENCES agents(id)` — a nullable FK. SQLite treats `""` as a non-NULL value and tries to resolve it in the `agents` table. No row exists with `id = ""`, so SQLite raises a FOREIGN KEY constraint failure (error 787), and the request fails with "failed to create job".

## Fix

In `HireAgentHandler` (`backend/jobs.go`), before the `INSERT INTO jobs` statement, convert an empty `req.AgentID` to `nil` so SQLite stores `NULL` rather than an empty string:

```go
var agentIDParam interface{}
if req.AgentID != "" {
    agentIDParam = req.AgentID
}
// pass agentIDParam (nil or string) to tx.Exec
```

## Tests

Added `TestHireAgentNoAgentID` to `backend/jobs_test.go` — exercises the previously-untested path of creating a job with no agent assigned.

Closes #56