### PR TITLE
fix: Handler Dashboard silent failure on expired token (issue #53)

### DIFF
--- a/frontend/src/routes/dashboard/handler/+page.svelte
+++ b/frontend/src/routes/dashboard/handler/+page.svelte
@@ -132,8 +132,10 @@
 				apiFetch('/api/ui/handlers/jobs'),
 				apiFetch('/api/ui/notifications')
 			]);
-			if (agentsRes.ok) agents = await agentsRes.json();
-			if (jobsRes.ok) jobs = await jobsRes.json();
+			if (!agentsRes.ok) throw new Error('Failed to load agents');
+			agents = await agentsRes.json();
+			if (!jobsRes.ok) throw new Error('Failed to load jobs');
+			jobs = await jobsRes.json();
 			if (notifRes.ok) notifications = await notifRes.json();
 		} catch (e: unknown) {
 			error = e instanceof Error ? e.message : 'Failed to load data';


### PR DESCRIPTION
## Summary

- Fixes the Handler Dashboard not displaying any error message when API requests fail (e.g., expired JWT token returns 401)
- The `loadData()` function was guarding with `if (res.ok)` but never throwing or setting the error state on failure, so the page silently showed empty lists
- Changed to `if (!res.ok) throw new Error(...)` for the agents and jobs fetches, which sets the `error` state and triggers the existing `{:else if error}` error display block in the template

## Root cause

In `loadData()` (handler `+page.svelte`), the original code:
```js
if (agentsRes.ok) agents = await agentsRes.json();
if (jobsRes.ok) jobs = await jobsRes.json();
```
skipped silently on non-OK responses. The employer dashboard already did this correctly by throwing on failure.

## Test plan
- [ ] Log in as a handler, let token expire (15 min), then navigate to `/dashboard/handler` — should now show "Failed to load agents" error instead of empty list
- [ ] With a valid token, dashboard still loads agents and jobs correctly
- [ ] Empty state (no agents yet) still shows the "No agents registered yet" message when request succeeds with empty array

Fixes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)