### PR TITLE
feat: Add delete button to Edit Job Brief (Issue #62)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1687,3 +1687,99 @@ func (app *App) DeleteMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(job)
 }
+
+// DeleteJobHandler permanently deletes a job brief and all its child records.
+// Deletion is only permitted when no agent has been assigned (agent_id IS NULL).
+// DELETE /api/ui/jobs/{id}
+func (app *App) DeleteJobHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "delete_job")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "EMPLOYER" {
+		log.Warn("authz failure: delete job requires EMPLOYER role", "role", role)
+		writeError(w, http.StatusForbidden, "only EMPLOYER role can delete jobs")
+		return
+	}
+
+	employerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "id")
+
+	// Verify ownership and that no agent is assigned.
+	var exists int
+	err := app.DB.QueryRow(
+		`SELECT 1 FROM jobs WHERE id = ? AND employer_id = ? AND agent_id IS NULL`,
+		jobID, employerID,
+	).Scan(&exists)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found, not owned by you, or an agent is already assigned")
+		return
+	}
+	if err != nil {
+		log.Error("delete job: db error checking ownership", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	tx, err := app.DB.Begin()
+	if err != nil {
+		log.Error("delete job: begin tx error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to begin transaction")
+		return
+	}
+	defer tx.Rollback()
+
+	// Delete child rows in dependency order.
+	if _, err = tx.Exec(
+		`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE job_id = ?)`,
+		jobID,
+	); err != nil {
+		log.Error("delete job: failed to delete criteria", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete job")
+		return
+	}
+
+	if _, err = tx.Exec(`DELETE FROM milestones WHERE job_id = ?`, jobID); err != nil {
+		log.Error("delete job: failed to delete milestones", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete job")
+		return
+	}
+
+	if _, err = tx.Exec(`DELETE FROM sow WHERE job_id = ?`, jobID); err != nil {
+		log.Error("delete job: failed to delete sow", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete job")
+		return
+	}
+
+	if _, err = tx.Exec(`DELETE FROM notifications WHERE job_id = ?`, jobID); err != nil {
+		log.Error("delete job: failed to delete notifications", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete job")
+		return
+	}
+
+	result, err := tx.Exec(
+		`DELETE FROM jobs WHERE id = ? AND employer_id = ? AND agent_id IS NULL`,
+		jobID, employerID,
+	)
+	if err != nil {
+		log.Error("delete job: failed to delete job row", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to delete job")
+		return
+	}
+
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		_ = tx.Rollback()
+		writeError(w, http.StatusConflict, "job could not be deleted — it may have been updated concurrently")
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Error("delete job: commit error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to commit transaction")
+		return
+	}
+
+	log.Info("job deleted", "job_id", jobID, "employer_id", employerID)
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/backend/router.go
+++ b/backend/router.go
@@ -116,6 +116,7 @@ func NewRouter(app *App) *chi.Mux {
 				r.Get("/", app.ListJobsHandler)
 				r.Get("/{id}", app.GetJobHandler)
 				r.Put("/{id}", app.UpdateJobHandler)
+				r.Delete("/{id}", app.DeleteJobHandler)
 				r.Post("/{id}/assign", app.AssignAgentHandler)
 				r.Post("/{job_id}/milestones", app.AddMilestoneHandler)
 				r.Put("/{job_id}/milestones/{milestone_id}", app.EditMilestoneHandler)

--- a/frontend/src/routes/jobs/[job_id]/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/edit/+page.svelte
@@ -43,6 +43,8 @@
 	let submitting = $state(false);
 	let error = $state('');
 	let loadError = $state('');
+	let deleting = $state(false);
+	let deleteError = $state('');
 
 	onMount(async () => {
 		if (!$isAuthenticated) {
@@ -111,6 +113,24 @@
 			submitting = false;
 		}
 	}
+
+	async function handleDelete() {
+		if (!confirm('Are you sure you want to permanently delete this job brief? This cannot be undone.')) return;
+		deleting = true;
+		deleteError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}`, { method: 'DELETE' });
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to delete job' }));
+				throw new Error(err.error || 'Failed to delete job');
+			}
+			goto('/dashboard/employer');
+		} catch (e: unknown) {
+			deleteError = e instanceof Error ? e.message : 'Failed to delete job';
+		} finally {
+			deleting = false;
+		}
+	}
 </script>
 
 <svelte:head>
@@ -171,11 +191,17 @@
 				</div>
 			</div>
 
-			<div style="display: flex; gap: 1rem;">
+			{#if deleteError}
+				<div class="alert alert-error">{deleteError}</div>
+			{/if}
+			<div style="display: flex; gap: 1rem; align-items: center;">
 				<button type="submit" class="btn btn-primary" disabled={submitting}>
 					{submitting ? 'Saving…' : 'Save Changes'}
 				</button>
 				<a href="/jobs/{jobId}" class="btn btn-secondary">Cancel</a>
+				<button type="button" class="btn btn-secondary" style="margin-left: auto; color: #c0392b; border-color: #c0392b;" disabled={deleting} onclick={handleDelete}>
+					{deleting ? 'Deleting…' : 'Delete Job'}
+				</button>
 			</div>
 		</form>
 	{/if}


### PR DESCRIPTION
## Summary
- Adds `DELETE /api/ui/jobs/{id}` endpoint with ownership verification and agent-assignment guard
- Cascades deletion to milestones, criteria, SOW, and notifications within a transaction
- Adds Delete Job button to the edit page with confirmation dialog, pushed to right side of action row
- Only allows deletion when no agent is assigned (same guard as edit)

## Test plan
- [ ] Create a job brief, navigate to edit page, verify Delete button appears
- [ ] Click Delete, confirm dialog, verify redirect to employer dashboard
- [ ] Verify job and all child records (milestones, criteria, SOW) are removed from DB
- [ ] Verify deleting a job with an assigned agent returns 409 Conflict
- [ ] Verify non-owner cannot delete another employer's job (403)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)