### PR TITLE
fix: add UNASSIGNED status for jobs with no agent offer (Issue #65)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -90,8 +90,8 @@ var migrations = []func(tx *sql.Tx) error{
 				id TEXT PRIMARY KEY,
 				employer_id TEXT NOT NULL REFERENCES users(id),
 				agent_id TEXT REFERENCES agents(id),
-				status TEXT NOT NULL DEFAULT 'PENDING_ACCEPTANCE' CHECK(status IN (
-					'PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
+				status TEXT NOT NULL DEFAULT 'UNASSIGNED' CHECK(status IN (
+					'UNASSIGNED','PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
 					'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
 				)),
 				title TEXT NOT NULL,
@@ -252,12 +252,89 @@ var migrations = []func(tx *sql.Tx) error{
 		}
 		return nil
 	},
+
+	// version 6 → 7: Issue #65 — add UNASSIGNED status to jobs table.
+	// UNASSIGNED is the initial status for newly created jobs that have no agent
+	// assigned yet. PENDING_ACCEPTANCE is reserved for jobs where an offer has
+	// been made to a specific agent. Because SQLite does not support ALTER TABLE
+	// ... MODIFY COLUMN, we must rebuild the table. This is handled by
+	// rawMigrations[6] below (requires PRAGMA foreign_keys = OFF at connection level).
+	func(tx *sql.Tx) error { return nil },
 }
 
 // rawMigrations holds migrations that need a raw *sql.DB (and therefore a raw
 // *sql.Conn via complexMigration) instead of a *sql.Tx. RunMigrations checks
 // this map first; if an entry exists it is used instead of migrations[i].
 var rawMigrations = map[int]func(db *sql.DB) error{
+	// version 6 → 7: Issue #65 — rebuild jobs table to add UNASSIGNED to the
+	// CHECK constraint and change the default status from PENDING_ACCEPTANCE to
+	// UNASSIGNED. Fresh databases already have UNASSIGNED in the schema from
+	// migration 0 (once that migration is updated), so we check whether UNASSIGNED
+	// is already in the constraint before doing the rebuild.
+	6: func(db *sql.DB) error {
+		ctx := context.Background()
+
+		// Idempotency check: read the current CREATE TABLE statement. If it
+		// already contains 'UNASSIGNED' the rebuild is not needed.
+		var createSQL string
+		err := db.QueryRowContext(ctx,
+			`SELECT sql FROM sqlite_master WHERE type='table' AND name='jobs'`,
+		).Scan(&createSQL)
+		if err != nil {
+			return fmt.Errorf("migration 6→7: read jobs schema: %w", err)
+		}
+		if strings.Contains(createSQL, "UNASSIGNED") {
+			return nil // Already up to date — fresh database.
+		}
+
+		return complexMigration(db, func(conn *sql.Conn) error {
+			tx, err := conn.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("migration 6→7: begin tx: %w", err)
+			}
+
+			stmts := []string{
+				`CREATE TABLE jobs_new (
+					id TEXT PRIMARY KEY,
+					employer_id TEXT NOT NULL REFERENCES users(id),
+					agent_id TEXT REFERENCES agents(id),
+					status TEXT NOT NULL DEFAULT 'UNASSIGNED' CHECK(status IN (
+						'UNASSIGNED','PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
+						'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
+					)),
+					title TEXT NOT NULL,
+					description TEXT DEFAULT '',
+					total_payout INTEGER NOT NULL,
+					timeline_days INTEGER NOT NULL,
+					sow_link TEXT DEFAULT '',
+					stripe_payment_intent TEXT,
+					stripe_checkout_session_id TEXT,
+					delivered_at DATETIME,
+					delivery_notes TEXT,
+					delivery_url TEXT,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				)`,
+				`INSERT INTO jobs_new SELECT * FROM jobs`,
+				`DROP TABLE jobs`,
+				`ALTER TABLE jobs_new RENAME TO jobs`,
+			}
+			for _, stmt := range stmts {
+				if _, execErr := tx.Exec(stmt); execErr != nil {
+					_ = tx.Rollback()
+					return fmt.Errorf("migration 6→7 rebuild jobs: %w\nSQL: %s", execErr, stmt)
+				}
+			}
+
+			if _, err := tx.Exec(`PRAGMA user_version = 7`); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("migration 6→7: set user_version: %w", err)
+			}
+
+			return tx.Commit()
+		})
+	},
+
 	// version 2 → 3: make jobs.agent_id nullable so retracted offers can clear it to NULL.
 	// Existing databases have agent_id NOT NULL; we rebuild via rename/copy/drop.
 	// Fresh databases already have the nullable schema from migration 0.

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -253,14 +253,19 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 		agentIDVal = req.AgentID
 	}
 
-	// When no agent is pre-assigned, the job starts with no agent and uses the
-	// default PENDING_ACCEPTANCE status. A separate assign-agent flow will move
-	// the job forward once an agent is selected.
+	// Set initial status based on whether an agent is being assigned up-front.
+	// UNASSIGNED: no agent selected yet — job is a draft brief with no offer made.
+	// PENDING_ACCEPTANCE: an agent has been selected and the offer is outstanding.
+	initialStatus := "UNASSIGNED"
+	if req.AgentID != "" {
+		initialStatus = "PENDING_ACCEPTANCE"
+	}
+
 	jobID := uuid.New().String()
 	_, err = tx.Exec(
-		`INSERT INTO jobs (id, employer_id, agent_id, title, description, total_payout, timeline_days, sow_link)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		jobID, employerID, agentIDVal, req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink,
+		`INSERT INTO jobs (id, employer_id, agent_id, status, title, description, total_payout, timeline_days, sow_link)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		jobID, employerID, agentIDVal, initialStatus, req.Title, req.Description, req.TotalPayout, req.TimelineDays, req.SowLink,
 	)
 	if err != nil {
 		log.Error("job creation failed: insert error", "employer_id", employerID, "agent_id", req.AgentID, "error", err)
@@ -504,10 +509,11 @@ func (app *App) AssignAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only allow assigning to jobs owned by this employer that have no agent yet
+	// Only allow assigning to UNASSIGNED jobs owned by this employer.
+	// UNASSIGNED means the job brief exists but no offer has been made yet.
 	result, err := app.DB.Exec(
 		`UPDATE jobs SET agent_id = ?, status = 'PENDING_ACCEPTANCE', updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND employer_id = ? AND (agent_id = '' OR agent_id IS NULL)`,
+		 WHERE id = ? AND employer_id = ? AND status = 'UNASSIGNED'`,
 		req.AgentID, jobID, employerID,
 	)
 	if err != nil {

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -61,9 +61,8 @@ func TestHireAgent(t *testing.T) {
 	}
 }
 
-// TestHireAgentNoAgentID verifies that a job can be created without an agent_id (i.e. agent_id
-// is omitted or empty). This was previously broken because an empty string was passed as the
-// agent_id FK value, causing a FOREIGN KEY constraint failure (SQLite error 787).
+// TestHireAgentNoAgentID verifies that a job created without an agent_id gets
+// UNASSIGNED status. No offer has been made yet, so the job is just a draft brief.
 func TestHireAgentNoAgentID(t *testing.T) {
 	t.Parallel()
 	app := setupTestApp(t)
@@ -94,8 +93,10 @@ func TestHireAgentNoAgentID(t *testing.T) {
 	if job.AgentID != "" {
 		t.Errorf("expected agent_id to be empty, got %q", job.AgentID)
 	}
-	if job.Status != "PENDING_ACCEPTANCE" {
-		t.Errorf("expected status PENDING_ACCEPTANCE, got %q", job.Status)
+	// A job created with no agent should be UNASSIGNED, not PENDING_ACCEPTANCE.
+	// PENDING_ACCEPTANCE is reserved for jobs where an offer has been made.
+	if job.Status != "UNASSIGNED" {
+		t.Errorf("expected status UNASSIGNED, got %q", job.Status)
 	}
 }
 

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -53,6 +53,7 @@
 
 	function statusBadge(status: string): string {
 		const map: Record<string, string> = {
+			UNASSIGNED: 'badge-open',
 			OPEN: 'badge-open',
 			SOW_NEGOTIATION: 'badge-sow',
 			AWAITING_PAYMENT: 'badge-awaiting-payment',

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -92,6 +92,7 @@
 
 	function statusBadgeClass(status: string): string {
 		const map: Record<string, string> = {
+			UNASSIGNED: 'badge-open',
 			OPEN: 'badge-open',
 			SOW_NEGOTIATION: 'badge-sow',
 			AWAITING_PAYMENT: 'badge-awaiting-payment',


### PR DESCRIPTION
## Summary

Fixes #65. Newly created Job Briefs (with no agent assigned) were showing `PENDING_ACCEPTANCE` status and a "Retract Offer" button even though no offer had been made.

- **New `UNASSIGNED` status**: Jobs created without an agent now start as `UNASSIGNED`. `PENDING_ACCEPTANCE` is reserved for jobs where an offer has actually been sent to an agent.
- **"Retract Offer" button**: Already guarded to only appear for `PENDING_ACCEPTANCE`, `SOW_NEGOTIATION`, and `AWAITING_PAYMENT` — so `UNASSIGNED` jobs won't show it.
- **Database migration**: Migration 6→7 rebuilds the `jobs` table to add `UNASSIGNED` to the `CHECK` constraint and changes the column default. Uses the same `complexMigration` pattern as migration 2→3 (requires `PRAGMA foreign_keys = OFF` at connection level). Idempotent — skips rebuild if `UNASSIGNED` already present.
- **`AssignAgentHandler`**: Now matches `status = 'UNASSIGNED'` instead of `agent_id IS NULL`, making the intent explicit.

## Changes

| File | Change |
|---|---|
| `backend/db.go` | Migration 0 schema updated; new migration 6→7 added to `rawMigrations` |
| `backend/jobs.go` | `HireAgentHandler` sets `UNASSIGNED`/`PENDING_ACCEPTANCE` based on `agent_id`; `AssignAgentHandler` matches on `UNASSIGNED` status |
| `backend/jobs_test.go` | `TestHireAgentNoAgentID` now expects `UNASSIGNED` |
| `frontend/.../employer/+page.svelte` | `UNASSIGNED` mapped to `badge-open` in status badge map |
| `frontend/.../jobs/[job_id]/+page.svelte` | Same badge map update |

## Test plan

- [ ] `go test ./...` passes (verified locally: `ok agentmarket 0.736s`)
- [ ] Create a new job brief without selecting an agent → status shows "Unassigned", no "Retract Offer" button
- [ ] Create a new job brief with an agent selected → status shows "Pending acceptance", "Retract Offer" button visible
- [ ] Assign an agent to an UNASSIGNED job → status transitions to PENDING_ACCEPTANCE
- [ ] Existing jobs in database are unaffected (migration is safe/idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)