### PR TITLE
refactor: link milestones to SoW instead of Jobs (#66)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -110,7 +110,7 @@ var migrations = []func(tx *sql.Tx) error{
 
 			`CREATE TABLE IF NOT EXISTS milestones (
 				id TEXT PRIMARY KEY,
-				job_id TEXT NOT NULL REFERENCES jobs(id),
+				sow_id TEXT NOT NULL REFERENCES sow(id),
 				title TEXT NOT NULL,
 				amount INTEGER NOT NULL,
 				order_index INTEGER NOT NULL,
@@ -259,6 +259,14 @@ var migrations = []func(tx *sql.Tx) error{
 	// been made to a specific agent. Because SQLite does not support ALTER TABLE
 	// ... MODIFY COLUMN, we must rebuild the table. This is handled by
 	// rawMigrations[6] below (requires PRAGMA foreign_keys = OFF at connection level).
+	func(tx *sql.Tx) error { return nil },
+
+	// version 7 → 8: Issue #66 — replace milestones.job_id with milestones.sow_id.
+	// Milestones now link directly to their Statement of Work rather than the job.
+	// The job can still be reached by traversing sow.job_id. Because SQLite does
+	// not support DROP COLUMN we rebuild the milestones table. This requires
+	// PRAGMA foreign_keys = OFF at the connection level and is handled by
+	// rawMigrations[7] below.
 	func(tx *sql.Tx) error { return nil },
 }
 
@@ -422,6 +430,85 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 			if _, err := tx.Exec(`PRAGMA user_version = 3`); err != nil {
 				_ = tx.Rollback()
 				return fmt.Errorf("migration 2→3: set user_version: %w", err)
+			}
+
+			return tx.Commit()
+		})
+	},
+
+	// version 7 → 8: Issue #66 — rebuild milestones to swap job_id for sow_id.
+	// Backfills sow_id from the job→sow relationship before dropping job_id.
+	// Fresh databases created after migration 0 is updated already have the new
+	// schema; we detect this by checking whether sow_id already exists on the table.
+	7: func(db *sql.DB) error {
+		ctx := context.Background()
+
+		// Idempotency check: if sow_id already exists, nothing to do.
+		rows, err := db.QueryContext(ctx, `PRAGMA table_info(milestones)`)
+		if err != nil {
+			return fmt.Errorf("migration 7→8: pragma table_info(milestones): %w", err)
+		}
+		hasSowID := false
+		for rows.Next() {
+			var cid int
+			var name, colType string
+			var notNull int
+			var dfltValue interface{}
+			var pk int
+			if scanErr := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); scanErr != nil {
+				rows.Close()
+				return fmt.Errorf("migration 7→8: scan table_info: %w", scanErr)
+			}
+			if name == "sow_id" {
+				hasSowID = true
+			}
+		}
+		rows.Close()
+		if hasSowID {
+			return nil // Already up to date — fresh database.
+		}
+
+		return complexMigration(db, func(conn *sql.Conn) error {
+			tx, err := conn.BeginTx(ctx, nil)
+			if err != nil {
+				return fmt.Errorf("migration 7→8: begin tx: %w", err)
+			}
+
+			stmts := []string{
+				`CREATE TABLE milestones_new (
+					id TEXT PRIMARY KEY,
+					sow_id TEXT NOT NULL REFERENCES sow(id),
+					title TEXT NOT NULL,
+					amount INTEGER NOT NULL,
+					order_index INTEGER NOT NULL,
+					deliverables TEXT NOT NULL DEFAULT '',
+					status TEXT NOT NULL DEFAULT 'PENDING' CHECK(status IN ('PENDING','REVIEW_REQUESTED','APPROVED','PAID')),
+					proof_of_work_url TEXT DEFAULT '',
+					proof_of_work_notes TEXT DEFAULT '',
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+				)`,
+				// Backfill: join milestones → sow on sow.job_id = milestones.job_id.
+				// Milestones with no matching sow row are dropped (they were orphaned).
+				`INSERT INTO milestones_new
+				 SELECT m.id, s.id, m.title, m.amount, m.order_index, m.deliverables,
+				        m.status, m.proof_of_work_url, m.proof_of_work_notes,
+				        m.created_at, m.updated_at
+				 FROM milestones m
+				 JOIN sow s ON s.job_id = m.job_id`,
+				`DROP TABLE milestones`,
+				`ALTER TABLE milestones_new RENAME TO milestones`,
+			}
+			for _, stmt := range stmts {
+				if _, execErr := tx.Exec(stmt); execErr != nil {
+					_ = tx.Rollback()
+					return fmt.Errorf("migration 7→8 rebuild milestones: %w\nSQL: %s", execErr, stmt)
+				}
+			}
+
+			if _, err := tx.Exec(`PRAGMA user_version = 8`); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("migration 7→8: set user_version: %w", err)
 			}
 
 			return tx.Commit()

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -27,7 +27,7 @@ type Criterion struct {
 
 type Milestone struct {
 	ID               string      `json:"id"`
-	JobID            string      `json:"job_id"`
+	SowID            string      `json:"sow_id"`
 	Title            string      `json:"title"`
 	Amount           int64       `json:"amount"`
 	OrderIndex       int         `json:"order_index"`
@@ -117,8 +117,10 @@ func (app *App) loadCriteriaForMilestone(milestoneID string) ([]Criterion, error
 
 func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 	rows, err := app.DB.Query(
-		`SELECT id, job_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
-		 FROM milestones WHERE job_id = ? ORDER BY order_index`,
+		`SELECT m.id, m.sow_id, m.title, m.amount, m.order_index, m.deliverables, m.status, m.proof_of_work_url, m.proof_of_work_notes, m.created_at, m.updated_at
+		 FROM milestones m
+		 JOIN sow s ON m.sow_id = s.id
+		 WHERE s.job_id = ? ORDER BY m.order_index`,
 		jobID,
 	)
 	if err != nil {
@@ -129,7 +131,7 @@ func (app *App) loadMilestonesForJob(jobID string) ([]Milestone, error) {
 	var milestones []Milestone
 	for rows.Next() {
 		var m Milestone
-		if err := rows.Scan(&m.ID, &m.JobID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
+		if err := rows.Scan(&m.ID, &m.SowID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
 			&m.ProofOfWorkURL, &m.ProofOfWorkNotes, &m.CreatedAt, &m.UpdatedAt); err != nil {
 			slog.Error("load milestones: scan error", "job_id", jobID, "error", err)
 			return nil, err
@@ -275,31 +277,10 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	for i, ms := range req.Milestones {
-		msID := uuid.New().String()
-		_, err = tx.Exec(
-			`INSERT INTO milestones (id, job_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
-			msID, jobID, ms.Title, ms.Amount, i, ms.Deliverables,
-		)
-		if err != nil {
-			log.Error("job creation failed: milestone insert error", "job_id", jobID, "milestone_index", i, "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to create milestone")
-			return
-		}
-
-		for _, criteriaDesc := range ms.Criteria {
-			cID := uuid.New().String()
-			_, err = tx.Exec(
-				`INSERT INTO criteria (id, milestone_id, description) VALUES (?, ?, ?)`,
-				cID, msID, criteriaDesc,
-			)
-			if err != nil {
-				log.Error("job creation failed: criteria insert error", "milestone_id", msID, "error", err)
-				writeError(w, http.StatusInternalServerError, "failed to create criteria")
-				return
-			}
-		}
-	}
+	// Milestones are now linked to sow_id (not job_id) and are managed during
+	// SOW negotiation via CreateOrUpdateSOW. Any milestones in the hire request
+	// are intentionally ignored here — they will be set once the agent accepts
+	// and a SOW is created.
 
 	if err := tx.Commit(); err != nil {
 		log.Error("job creation failed: commit error", "job_id", jobID, "error", err)
@@ -313,7 +294,6 @@ func (app *App) HireAgentHandler(w http.ResponseWriter, r *http.Request) {
 		"agent_id", req.AgentID,
 		"title", req.Title,
 		"total_payout", req.TotalPayout,
-		"milestones", len(req.Milestones),
 	)
 
 	// Notify the agent's handler when a job offer is created with an agent assigned
@@ -406,44 +386,9 @@ func (app *App) UpdateJobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Delete existing milestones and criteria, then re-insert
-	_, err = tx.Exec(`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE job_id = ?)`, jobID)
-	if err != nil {
-		log.Error("update job: delete criteria error", "job_id", jobID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to update milestones")
-		return
-	}
-	_, err = tx.Exec(`DELETE FROM milestones WHERE job_id = ?`, jobID)
-	if err != nil {
-		log.Error("update job: delete milestones error", "job_id", jobID, "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to update milestones")
-		return
-	}
-
-	for i, ms := range req.Milestones {
-		msID := uuid.New().String()
-		_, err = tx.Exec(
-			`INSERT INTO milestones (id, job_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
-			msID, jobID, ms.Title, ms.Amount, i, ms.Deliverables,
-		)
-		if err != nil {
-			log.Error("update job: milestone insert error", "job_id", jobID, "milestone_index", i, "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to update milestone")
-			return
-		}
-		for _, criteriaDesc := range ms.Criteria {
-			cID := uuid.New().String()
-			_, err = tx.Exec(
-				`INSERT INTO criteria (id, milestone_id, description) VALUES (?, ?, ?)`,
-				cID, msID, criteriaDesc,
-			)
-			if err != nil {
-				log.Error("update job: criteria insert error", "milestone_id", msID, "error", err)
-				writeError(w, http.StatusInternalServerError, "failed to update criteria")
-				return
-			}
-		}
-	}
+	// Milestones are now linked to sow_id (not job_id) and are managed during
+	// SOW negotiation via CreateOrUpdateSOW. Job updates only touch the job brief;
+	// milestone changes are handled through the SOW endpoint.
 
 	if err := tx.Commit(); err != nil {
 		log.Error("update job: commit error", "job_id", jobID, "error", err)
@@ -675,7 +620,7 @@ func (app *App) ApproveMilestoneHandler(w http.ResponseWriter, r *http.Request) 
 
 	result, err := app.DB.Exec(
 		`UPDATE milestones SET status = 'APPROVED', updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND job_id = ? AND status = 'REVIEW_REQUESTED'`,
+		 WHERE id = ? AND sow_id = (SELECT id FROM sow WHERE job_id = ?) AND status = 'REVIEW_REQUESTED'`,
 		milestoneID, jobID,
 	)
 	if err != nil {
@@ -694,11 +639,11 @@ func (app *App) ApproveMilestoneHandler(w http.ResponseWriter, r *http.Request) 
 
 	var m Milestone
 	row := app.DB.QueryRow(
-		`SELECT id, job_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
+		`SELECT id, sow_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
 		 FROM milestones WHERE id = ?`,
 		milestoneID,
 	)
-	if err := row.Scan(&m.ID, &m.JobID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
+	if err := row.Scan(&m.ID, &m.SowID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
 		&m.ProofOfWorkURL, &m.ProofOfWorkNotes, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		log.Error("milestone approval: failed to retrieve after update", "milestone_id", milestoneID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to retrieve milestone")
@@ -905,7 +850,7 @@ func (app *App) SubmitMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := app.DB.Exec(
 		`UPDATE milestones SET status = 'REVIEW_REQUESTED', proof_of_work_url = ?, proof_of_work_notes = ?, updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND job_id = ? AND status = 'PENDING'`,
+		 WHERE id = ? AND sow_id = (SELECT id FROM sow WHERE job_id = ?) AND status = 'PENDING'`,
 		req.ProofOfWorkURL, req.ProofOfWorkNotes, milestoneID, jobID,
 	)
 	if err != nil {
@@ -929,11 +874,11 @@ func (app *App) SubmitMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 
 	var m Milestone
 	row := app.DB.QueryRow(
-		`SELECT id, job_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
+		`SELECT id, sow_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
 		 FROM milestones WHERE id = ?`,
 		milestoneID,
 	)
-	if err := row.Scan(&m.ID, &m.JobID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
+	if err := row.Scan(&m.ID, &m.SowID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
 		&m.ProofOfWorkURL, &m.ProofOfWorkNotes, &m.CreatedAt, &m.UpdatedAt); err != nil {
 		log.Error("milestone submit: failed to retrieve after update", "milestone_id", milestoneID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to retrieve milestone")

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -29,10 +29,6 @@ func TestHireAgent(t *testing.T) {
 		Description:  "The details",
 		TotalPayout:  5000,
 		TimelineDays: 7,
-		Milestones: []MilestoneInput{
-			{Title: "Design", Amount: 2000, Criteria: []string{"wireframes done"}},
-			{Title: "Build", Amount: 3000, Criteria: []string{"code merged", "tests pass"}},
-		},
 	}
 	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire", body, token)
 	if rr.Code != http.StatusCreated {
@@ -49,15 +45,10 @@ func TestHireAgent(t *testing.T) {
 	if job.Status != "PENDING_ACCEPTANCE" {
 		t.Errorf("expected status PENDING_ACCEPTANCE, got %q", job.Status)
 	}
-	if len(job.Milestones) != 2 {
-		t.Errorf("expected 2 milestones, got %d", len(job.Milestones))
-	}
-	// Verify criteria were persisted.
-	if len(job.Milestones[0].Criteria) != 1 {
-		t.Errorf("milestone 0: expected 1 criterion, got %d", len(job.Milestones[0].Criteria))
-	}
-	if len(job.Milestones[1].Criteria) != 2 {
-		t.Errorf("milestone 1: expected 2 criteria, got %d", len(job.Milestones[1].Criteria))
+	// Milestones are now linked to sow_id and are set during SOW negotiation,
+	// not at job creation time. No milestones should be present at hire time.
+	if len(job.Milestones) != 0 {
+		t.Errorf("expected 0 milestones at hire time (milestones belong to SOW), got %d", len(job.Milestones))
 	}
 }
 

--- a/backend/sow.go
+++ b/backend/sow.go
@@ -163,26 +163,33 @@ func (app *App) CreateOrUpdateSOW(w http.ResponseWriter, r *http.Request) {
 		log.Info("SOW updated", "job_id", jobID, "sow_id", existingID, "user_id", userID)
 	}
 
-	// Update milestones if provided in the request
+	// Update milestones if provided in the request.
+	// Milestones now reference sow_id directly; look up the SOW id for this job.
 	if req.Milestones != nil {
-		// Delete existing milestones and criteria for this job, then re-insert
-		if _, err = app.DB.Exec(`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE job_id = ?)`, jobID); err != nil {
-			log.Error("sow upsert: delete criteria error", "job_id", jobID, "error", err)
+		var sowID string
+		if err = app.DB.QueryRow("SELECT id FROM sow WHERE job_id = ?", jobID).Scan(&sowID); err != nil {
+			log.Error("sow upsert: failed to resolve sow_id for milestones", "job_id", jobID, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to resolve SOW")
+			return
+		}
+		// Delete existing milestones and criteria for this SOW, then re-insert
+		if _, err = app.DB.Exec(`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE sow_id = ?)`, sowID); err != nil {
+			log.Error("sow upsert: delete criteria error", "sow_id", sowID, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to update milestones")
 			return
 		}
-		if _, err = app.DB.Exec(`DELETE FROM milestones WHERE job_id = ?`, jobID); err != nil {
-			log.Error("sow upsert: delete milestones error", "job_id", jobID, "error", err)
+		if _, err = app.DB.Exec(`DELETE FROM milestones WHERE sow_id = ?`, sowID); err != nil {
+			log.Error("sow upsert: delete milestones error", "sow_id", sowID, "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to update milestones")
 			return
 		}
 		for i, ms := range req.Milestones {
 			msID := uuid.New().String()
 			if _, err = app.DB.Exec(
-				`INSERT INTO milestones (id, job_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
-				msID, jobID, ms.Title, ms.Amount, i, ms.Deliverables,
+				`INSERT INTO milestones (id, sow_id, title, amount, order_index, deliverables) VALUES (?, ?, ?, ?, ?, ?)`,
+				msID, sowID, ms.Title, ms.Amount, i, ms.Deliverables,
 			); err != nil {
-				log.Error("sow upsert: milestone insert error", "job_id", jobID, "milestone_index", i, "error", err)
+				log.Error("sow upsert: milestone insert error", "sow_id", sowID, "milestone_index", i, "error", err)
 				writeError(w, http.StatusInternalServerError, "failed to create milestone")
 				return
 			}
@@ -198,7 +205,7 @@ func (app *App) CreateOrUpdateSOW(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-		log.Info("SOW milestones updated", "job_id", jobID, "count", len(req.Milestones))
+		log.Info("SOW milestones updated", "sow_id", sowID, "count", len(req.Milestones))
 	}
 
 	sow, err := app.getSOWByJobID(jobID)


### PR DESCRIPTION
## Summary
- Migrates `milestones.job_id` to `milestones.sow_id`, linking milestones to Statements of Work instead of Jobs directly
- Adds migration 7→8 that rebuilds the milestones table and backfills `sow_id` from the existing `sow.job_id` relationship (orphaned milestones with no matching SOW are dropped)
- Updates Go models (`Milestone.JobID` → `Milestone.SowID`), all SQL queries, and the SOW upsert handler to work with the new column
- Milestone insert is removed from `HireAgentHandler` and `UpdateJobHandler` — milestones now belong exclusively to the SOW, so they are created/updated during SOW negotiation via `CreateOrUpdateSOW`

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)