### PR TITLE
fix: handle empty-string timestamps in sqliteTime.Scan (#69)

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -42,6 +42,12 @@ func (s sqliteTime) Scan(src interface{}) error {
 		*s.t = v
 		return nil
 	case string:
+		// Treat empty string as zero/NULL time — existing rows may have
+		// updated_at = "" (empty string, not NULL) rather than a real timestamp.
+		if v == "" {
+			*s.t = time.Time{}
+			return nil
+		}
 		for _, layout := range sqliteTimeFormats {
 			if t, err := time.Parse(layout, v); err == nil {
 				*s.t = t


### PR DESCRIPTION
## Summary

- Fixes a crash on the Employer Dashboard ("Failed to load jobs") caused by existing job rows that have `updated_at = ""` (empty string, not NULL)
- The `sqliteTime.Scan` method already handled `nil`/NULL correctly, but returned a parse error for an empty string
- Added a one-line guard: treat `""` identically to `nil` — assign `time.Time{}` (zero value) and return nil

## Root cause

`modernc.org/sqlite` returns DATETIME columns as plain strings. The previous commit on this branch (72b7332) introduced `sqliteTime` to handle that conversion, but didn't account for rows where the column value is `""` rather than a proper timestamp or NULL.

## Test plan

- [ ] Deploy to staging and verify the Employer Dashboard loads without error
- [ ] Confirm jobs with `updated_at = ""` are returned with a zero `time.Time` (serialised as `"0001-01-01T00:00:00Z"` in JSON)
- [ ] Confirm jobs with a real timestamp still parse correctly
- [ ] Run existing test suite: `go test ./...`

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)