### PR TITLE
Fix issues #76, #77, #79, #80

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1119,6 +1119,183 @@ func (app *App) RequestRevisionHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(j)
 }
 
+// UIAcceptJobHandler allows an AGENT_HANDLER to accept a job offer via the UI (JWT auth).
+// This mirrors AcceptJobHandler (which uses API key auth) but is called from the web frontend.
+// POST /api/ui/jobs/{id}/accept
+func (app *App) UIAcceptJobHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "ui_accept_job")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "AGENT_HANDLER" {
+		log.Warn("authz failure: accept job requires AGENT_HANDLER role", "role", role)
+		writeError(w, http.StatusForbidden, "only AGENT_HANDLER role can accept job offers")
+		return
+	}
+
+	handlerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "id")
+
+	// Load job — verify it belongs to one of this handler's agents and is awaiting acceptance.
+	var totalPayout int64
+	var timelineDays int
+	var agentID string
+	err := app.DB.QueryRow(
+		`SELECT j.total_payout, j.timeline_days, j.agent_id
+		   FROM jobs j
+		   JOIN agents a ON j.agent_id = a.id
+		  WHERE j.id = ? AND a.handler_id = ? AND j.status = 'PENDING_ACCEPTANCE'`,
+		jobID, handlerID,
+	).Scan(&totalPayout, &timelineDays, &agentID)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		return
+	}
+	if err != nil {
+		log.Error("ui accept job: db error", "job_id", jobID, "handler_id", handlerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	tx, err := app.DB.Begin()
+	if err != nil {
+		log.Error("ui accept job: begin transaction error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	defer tx.Rollback()
+
+	result, err := tx.Exec(
+		`UPDATE jobs SET status = 'SOW_NEGOTIATION', updated_at = CURRENT_TIMESTAMP
+		  WHERE id = ? AND agent_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		jobID, agentID,
+	)
+	if err != nil {
+		log.Error("ui accept job: update error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		return
+	}
+
+	sowID := uuid.New().String()
+	_, err = tx.Exec(
+		`INSERT INTO sow (id, job_id, detailed_spec, work_process, price_cents, timeline_days, agent_accepted, employer_accepted)
+		 VALUES (?, ?, '', '', ?, ?, 0, 0)`,
+		sowID, jobID, totalPayout, timelineDays,
+	)
+	if err != nil {
+		log.Error("ui accept job: failed to create default SOW", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create default SOW")
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Error("ui accept job: commit error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	log.Info("job accepted via UI, moved to SOW_NEGOTIATION", "job_id", jobID, "handler_id", handlerID)
+
+	j, err := app.getJobDetail(jobID)
+	if err != nil {
+		log.Error("ui accept job: failed to retrieve after update", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve job")
+		return
+	}
+
+	_ = app.CreateNotification(j.EmployerID, jobID, NotifJobOfferAccepted,
+		"Job offer accepted: "+j.Title,
+		"Your job offer has been accepted. SOW negotiation has begun.")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(j)
+}
+
+// UIRejectJobHandler allows an AGENT_HANDLER to reject a job offer via the UI (JWT auth).
+// The job is reset to UNASSIGNED (agent cleared) and the employer is notified with the reason.
+// POST /api/ui/jobs/{id}/reject
+func (app *App) UIRejectJobHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "ui_reject_job")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "AGENT_HANDLER" {
+		log.Warn("authz failure: reject job requires AGENT_HANDLER role", "role", role)
+		writeError(w, http.StatusForbidden, "only AGENT_HANDLER role can reject job offers")
+		return
+	}
+
+	handlerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "id")
+
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Reason == "" {
+		writeError(w, http.StatusBadRequest, "reason is required when rejecting a job offer")
+		return
+	}
+
+	// Verify the job belongs to one of this handler's agents and is awaiting acceptance.
+	var agentID string
+	err := app.DB.QueryRow(
+		`SELECT j.agent_id
+		   FROM jobs j
+		   JOIN agents a ON j.agent_id = a.id
+		  WHERE j.id = ? AND a.handler_id = ? AND j.status = 'PENDING_ACCEPTANCE'`,
+		jobID, handlerID,
+	).Scan(&agentID)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		return
+	}
+	if err != nil {
+		log.Error("ui reject job: db error", "job_id", jobID, "handler_id", handlerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	// Reset the job to UNASSIGNED, clearing the agent assignment.
+	result, err := app.DB.Exec(
+		`UPDATE jobs SET status = 'UNASSIGNED', agent_id = NULL, updated_at = CURRENT_TIMESTAMP
+		  WHERE id = ? AND agent_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		jobID, agentID,
+	)
+	if err != nil {
+		log.Error("ui reject job: update error", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		return
+	}
+
+	log.Info("job rejected via UI, reset to UNASSIGNED", "job_id", jobID, "handler_id", handlerID)
+
+	j, err := app.getJobDetail(jobID)
+	if err != nil {
+		log.Error("ui reject job: failed to retrieve after update", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve job")
+		return
+	}
+
+	_ = app.CreateNotification(j.EmployerID, jobID, NotifJobOfferRejected,
+		"Job offer declined: "+j.Title,
+		"Your job offer was declined. Reason: "+req.Reason)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(j)
+}
+
 // RetractOfferHandler allows an employer to retract a job offer before both parties have
 // committed via payment. Retraction is permitted while the job is in any of:
 //   - PENDING_ACCEPTANCE  — agent has not yet accepted
@@ -1686,7 +1863,7 @@ func (app *App) DeleteJobHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Delete child rows in dependency order.
 	if _, err = tx.Exec(
-		`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE job_id = ?)`,
+		`DELETE FROM criteria WHERE milestone_id IN (SELECT id FROM milestones WHERE sow_id IN (SELECT id FROM sow WHERE job_id = ?))`,
 		jobID,
 	); err != nil {
 		log.Error("delete job: failed to delete criteria", "job_id", jobID, "error", err)
@@ -1694,7 +1871,7 @@ func (app *App) DeleteJobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if _, err = tx.Exec(`DELETE FROM milestones WHERE job_id = ?`, jobID); err != nil {
+	if _, err = tx.Exec(`DELETE FROM milestones WHERE sow_id IN (SELECT id FROM sow WHERE job_id = ?)`, jobID); err != nil {
 		log.Error("delete job: failed to delete milestones", "job_id", jobID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to delete job")
 		return

--- a/backend/router.go
+++ b/backend/router.go
@@ -126,6 +126,8 @@ func NewRouter(app *App) *chi.Mux {
 				r.Get("/{job_id}/sow", app.GetSOW)
 				r.Post("/{job_id}/sow/accept", app.AcceptSOW)
 				r.Post("/{job_id}/checkout", app.CreateCheckoutHandler)
+				r.Post("/{id}/accept", app.UIAcceptJobHandler)
+				r.Post("/{id}/reject", app.UIRejectJobHandler)
 				r.Post("/{id}/retract", app.RetractOfferHandler)
 				r.Post("/{job_id}/approve-delivery", app.ApproveDeliveryHandler)
 				r.Post("/{job_id}/request-revision", app.RequestRevisionHandler)

--- a/frontend/src/routes/dashboard/handler/+page.svelte
+++ b/frontend/src/routes/dashboard/handler/+page.svelte
@@ -21,6 +21,7 @@
 		id: string;
 		employer_id: string;
 		agent_id: string;
+		agent_name?: string;
 		title: string;
 		status: string;
 		total_payout: number;
@@ -339,7 +340,7 @@
 						{#each jobs as job}
 							<tr>
 								<td><a href="/jobs/{job.id}" style="font-weight: 600; color: #1a1a1a; text-decoration: none;">{job.title}</a></td>
-								<td style="font-size: 0.88rem;">Agent #{job.agent_id.slice(0, 8)}</td>
+								<td style="font-size: 0.88rem;">{job.agent_name || job.agent_id.slice(0, 8)}</td>
 								<td style="font-size: 0.88rem; color: #666;">Employer</td>
 								<td><span class="badge {statusBadge(job.status)}">{statusLabel(job.status)}</span></td>
 								<td style="font-variant-numeric: tabular-nums;">${job.total_payout.toFixed(2)}</td>

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -86,6 +86,12 @@
 	let retractError = $state('');
 	let deleting = $state(false);
 	let deleteError = $state('');
+	let acceptLoading = $state(false);
+	let acceptError = $state('');
+	let rejectLoading = $state(false);
+	let rejectError = $state('');
+	let rejectReason = $state('');
+	let showRejectForm = $state(false);
 
 	const isEmployer = $derived($auth?.role === 'EMPLOYER');
 	const isHandler = $derived($auth?.role === 'AGENT_HANDLER');
@@ -191,6 +197,50 @@
 			deleteError = e instanceof Error ? e.message : 'Failed to delete job';
 		} finally {
 			deleting = false;
+		}
+	}
+
+	async function handleAcceptOffer() {
+		acceptLoading = true;
+		acceptError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/accept`, { method: 'POST' });
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to accept offer' }));
+				throw new Error(err.error || 'Failed to accept offer');
+			}
+			await loadJob();
+		} catch (e: unknown) {
+			acceptError = e instanceof Error ? e.message : 'Failed to accept offer';
+		} finally {
+			acceptLoading = false;
+		}
+	}
+
+	async function handleRejectOffer() {
+		if (!rejectReason.trim()) {
+			rejectError = 'Please provide a reason for rejection.';
+			return;
+		}
+		rejectLoading = true;
+		rejectError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/reject`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ reason: rejectReason.trim() })
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to reject offer' }));
+				throw new Error(err.error || 'Failed to reject offer');
+			}
+			rejectReason = '';
+			showRejectForm = false;
+			await loadJob();
+		} catch (e: unknown) {
+			rejectError = e instanceof Error ? e.message : 'Failed to reject offer';
+		} finally {
+			rejectLoading = false;
 		}
 	}
 
@@ -325,6 +375,70 @@
 				{/if}
 			</div>
 		</div>
+
+		<!-- Accept / Reject offer (handler only, when job is PENDING_ACCEPTANCE) -->
+		{#if job.status === 'PENDING_ACCEPTANCE' && isHandler}
+			<div class="card" style="margin-bottom: 1.5rem; border-color: #a5b4fc; background: #eef2ff;">
+				<h3 style="margin: 0 0 0.5rem; font-size: 1rem;">Job Offer — Action Required</h3>
+				<p style="margin: 0 0 1rem; color: #555; font-size: 0.9rem;">You have received a job offer. Accept to begin SoW negotiation, or reject and return the job to open status.</p>
+
+				{#if acceptError}
+					<div class="alert alert-error" style="margin-bottom: 0.75rem;">{acceptError}</div>
+				{/if}
+
+				{#if !showRejectForm}
+					<div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+						<button
+							class="btn btn-primary"
+							onclick={handleAcceptOffer}
+							disabled={acceptLoading || rejectLoading}
+						>
+							{acceptLoading ? 'Accepting…' : 'Accept Offer'}
+						</button>
+						<button
+							class="btn btn-secondary"
+							style="color: #991b1b; border-color: #fca5a5;"
+							onclick={() => { showRejectForm = true; rejectError = ''; }}
+							disabled={acceptLoading}
+						>
+							Reject Offer
+						</button>
+					</div>
+				{:else}
+					<div>
+						{#if rejectError}
+							<div class="alert alert-error" style="margin-bottom: 0.75rem;">{rejectError}</div>
+						{/if}
+						<div class="form-group" style="margin-bottom: 0.75rem;">
+							<label for="reject-reason" style="font-weight: 600; font-size: 0.9rem;">Reason for rejection <span style="color: #991b1b;">*</span></label>
+							<textarea
+								id="reject-reason"
+								bind:value={rejectReason}
+								placeholder="Please explain why you are declining this offer. This message will be sent to the employer."
+								style="min-height: 80px; margin-top: 0.35rem;"
+							></textarea>
+						</div>
+						<div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+							<button
+								class="btn btn-secondary"
+								style="color: #991b1b; border-color: #fca5a5;"
+								onclick={handleRejectOffer}
+								disabled={rejectLoading}
+							>
+								{rejectLoading ? 'Rejecting…' : 'Confirm Rejection'}
+							</button>
+							<button
+								class="btn"
+								onclick={() => { showRejectForm = false; rejectReason = ''; rejectError = ''; }}
+								disabled={rejectLoading}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+		{/if}
 
 		<!-- Awaiting payment — Pay Now button (employer only) -->
 		{#if job.status === 'AWAITING_PAYMENT' && isEmployer}

--- a/frontend/src/routes/jobs/new/+page.svelte
+++ b/frontend/src/routes/jobs/new/+page.svelte
@@ -33,8 +33,6 @@
 	let description = $state('');
 	let payout = $state(0);
 	let timeline = $state('');
-	let sowLink = $state('');
-
 	let submitting = $state(false);
 	let error = $state('');
 
@@ -62,7 +60,6 @@
 				description,
 				total_payout: Math.round(Number(payout)),
 				timeline_days: Math.round(Number(timeline)) || 0,
-				sow_link: sowLink,
 				milestones: []
 			};
 			const res = await apiFetch('/api/ui/jobs/hire', {
@@ -125,13 +122,9 @@
 
 		<div class="card" style="margin-bottom: 1.5rem;">
 			<h2 style="margin: 0 0 0.4rem; font-size: 1.1rem;">Statement of Work</h2>
-			<p style="margin: 0 0 1rem; font-size: 0.9rem; color: #666;">
-				You'll negotiate detailed specs, deliverables, and milestones with the agent once they're assigned. Optionally link an existing SoW doc to get things started.
+			<p style="margin: 0; font-size: 0.9rem; color: #666;">
+				You'll create detailed specs, deliverables, and milestones during negotiations with an agent. Optionally, you can enter an SoW after saving the Job Brief.
 			</p>
-			<div class="form-group" style="margin-bottom: 0;">
-				<label for="sow-link">SoW document URL <span style="font-weight: normal; color: #888;">(optional)</span></label>
-				<input id="sow-link" type="url" bind:value={sowLink} placeholder="https://docs.google.com/..." />
-			</div>
 		</div>
 
 		<div style="display: flex; gap: 1rem;">


### PR DESCRIPTION
## Summary
- **#76**: Fix delete job SQL bug — `milestones` uses `sow_id` not `job_id`, corrected subqueries to traverse through `sow` table
- **#77**: Remove SoW document URL input from `/jobs/new` form, replaced with workflow explanation text
- **#79**: Add Accept/Reject buttons for `PENDING_ACCEPTANCE` jobs in agent job detail view — Accept transitions to `SOW_NEGOTIATION` with default SOW, Reject resets to `UNASSIGNED` with required reason notification
- **#80**: Display agent name instead of truncated agent ID in handler dashboard incoming jobs table

## Test plan
- [ ] Verify job deletion works without SQL errors
- [ ] Check `/jobs/new` form no longer shows SoW URL input
- [ ] Test Accept button on PENDING_ACCEPTANCE job as agent handler
- [ ] Test Reject button with reason text on PENDING_ACCEPTANCE job
- [ ] Verify agent name shows in handler dashboard job list

Closes #76, closes #77, closes #79, closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)