### PR TITLE
Fix issues #81, #82, #84, #85, #86, #87

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -143,7 +143,7 @@ var migrations = []func(tx *sql.Tx) error{
 				agent_id TEXT REFERENCES agents(id),
 				status TEXT NOT NULL DEFAULT 'UNASSIGNED' CHECK(status IN (
 					'UNASSIGNED','PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
-					'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
+					'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED'
 				)),
 				title TEXT NOT NULL,
 				description TEXT DEFAULT '',
@@ -359,7 +359,7 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 					agent_id TEXT REFERENCES agents(id),
 					status TEXT NOT NULL DEFAULT 'UNASSIGNED' CHECK(status IN (
 						'UNASSIGNED','PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
-						'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
+						'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED'
 					)),
 					title TEXT NOT NULL,
 					description TEXT DEFAULT '',
@@ -449,7 +449,7 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 					agent_id TEXT REFERENCES agents(id),
 					status TEXT NOT NULL DEFAULT 'PENDING_ACCEPTANCE' CHECK(status IN (
 						'PENDING_ACCEPTANCE','IN_PROGRESS','COMPLETED','DISPUTED','CANCELLED',
-						'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED','RETRACTED'
+						'SOW_NEGOTIATION','AWAITING_PAYMENT','DELIVERED'
 					)),
 					title TEXT NOT NULL,
 					description TEXT DEFAULT '',

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1368,7 +1368,7 @@ func (app *App) RetractOfferHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := app.DB.Exec(
 		`UPDATE jobs
-		    SET status = 'RETRACTED',
+		    SET status = 'UNASSIGNED',
 		        agent_id = NULL,
 		        stripe_checkout_session_id = NULL,
 		        updated_at = CURRENT_TIMESTAMP

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -290,14 +290,14 @@ func TestRetractOffer(t *testing.T) {
 	}
 	var retracted Job
 	json.Unmarshal(rr.Body.Bytes(), &retracted)
-	if retracted.Status != "RETRACTED" {
-		t.Errorf("expected RETRACTED status, got %q", retracted.Status)
+	if retracted.Status != "UNASSIGNED" {
+		t.Errorf("expected UNASSIGNED status, got %q", retracted.Status)
 	}
 	if retracted.AgentID != "" {
 		t.Errorf("expected agent_id to be cleared, got %q", retracted.AgentID)
 	}
 
-	// Retracting again should fail — status is now RETRACTED (not a retractable status)
+	// Retracting again should fail — status is now UNASSIGNED (not a retractable status)
 	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/retract", nil, employerToken)
 	if rr.Code != http.StatusConflict {
 		t.Errorf("double-retract: expected 409, got %d", rr.Code)
@@ -366,8 +366,8 @@ func TestRetractOfferDuringSowNegotiation(t *testing.T) {
 	}
 	var retracted Job
 	json.Unmarshal(rr.Body.Bytes(), &retracted)
-	if retracted.Status != "RETRACTED" {
-		t.Errorf("expected RETRACTED, got %q", retracted.Status)
+	if retracted.Status != "UNASSIGNED" {
+		t.Errorf("expected UNASSIGNED, got %q", retracted.Status)
 	}
 	if retracted.AgentID != "" {
 		t.Errorf("expected agent_id cleared, got %q", retracted.AgentID)

--- a/backend/notifications.go
+++ b/backend/notifications.go
@@ -62,14 +62,19 @@ func (app *App) CreateNotification(userID, jobID, notifType, title, message stri
 	slog.Info("notification created", "id", id, "user_id", userID, "type", notifType)
 
 	// Send email — best effort, do not fail if email fails
-	var email string
-	if err := app.DB.QueryRow("SELECT email FROM users WHERE id = ?", userID).Scan(&email); err != nil {
+	var email, role string
+	if err := app.DB.QueryRow("SELECT email, role FROM users WHERE id = ?", userID).Scan(&email, &role); err != nil {
 		slog.Warn("notification: could not fetch user email", "user_id", userID, "error", err)
 		return nil
 	}
 
+	dashboardPath := "/dashboard/employer"
+	if role == "AGENT_HANDLER" {
+		dashboardPath = "/dashboard/handler"
+	}
+
 	htmlBody := "<h2>" + title + "</h2><p>" + message + "</p>" +
-		"<p><a href=\"" + app.Config.BaseURL + "/dashboard\">View on AgentMarket</a></p>"
+		"<p><a href=\"" + app.Config.BaseURL + dashboardPath + "\">View on AgentMarket</a></p>"
 
 	if err := SendEmail(app.Config.ResendAPIKey, email, title, htmlBody); err != nil {
 		slog.Warn("notification email failed", "user_id", userID, "type", notifType, "error", err)

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -62,8 +62,7 @@
 			COMPLETED: 'badge-completed',
 			PENDING: 'badge-pending',
 			PENDING_ACCEPTANCE: 'badge-pending',
-			CANCELLED: 'badge-cancelled',
-			RETRACTED: 'badge-cancelled'
+			CANCELLED: 'badge-cancelled'
 		};
 		return map[status] ?? 'badge-pending';
 	}

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -107,8 +107,7 @@
 			COMPLETED: 'badge-completed',
 			PENDING: 'badge-pending',
 			PENDING_ACCEPTANCE: 'badge-pending',
-			CANCELLED: 'badge-cancelled',
-			RETRACTED: 'badge-cancelled'
+			CANCELLED: 'badge-cancelled'
 		};
 		return map[status] ?? 'badge-pending';
 	}
@@ -236,7 +235,7 @@
 			}
 			rejectReason = '';
 			showRejectForm = false;
-			await loadJob();
+			goto('/dashboard/handler');
 		} catch (e: unknown) {
 			rejectError = e instanceof Error ? e.message : 'Failed to reject offer';
 		} finally {
@@ -376,11 +375,11 @@
 			</div>
 		</div>
 
-		<!-- Accept / Reject offer (handler only, when job is PENDING_ACCEPTANCE) -->
+		<!-- Accept / Decline offer (handler only, when job is PENDING_ACCEPTANCE) -->
 		{#if job.status === 'PENDING_ACCEPTANCE' && isHandler}
 			<div class="card" style="margin-bottom: 1.5rem; border-color: #a5b4fc; background: #eef2ff;">
 				<h3 style="margin: 0 0 0.5rem; font-size: 1rem;">Job Offer — Action Required</h3>
-				<p style="margin: 0 0 1rem; color: #555; font-size: 0.9rem;">You have received a job offer. Accept to begin SoW negotiation, or reject and return the job to open status.</p>
+				<p style="margin: 0 0 1rem; color: #555; font-size: 0.9rem;">You have received a job offer. Accept to begin SoW negotiation, or decline and return the job to open status.</p>
 
 				{#if acceptError}
 					<div class="alert alert-error" style="margin-bottom: 0.75rem;">{acceptError}</div>
@@ -401,7 +400,7 @@
 							onclick={() => { showRejectForm = true; rejectError = ''; }}
 							disabled={acceptLoading}
 						>
-							Reject Offer
+							Decline Offer
 						</button>
 					</div>
 				{:else}
@@ -410,7 +409,7 @@
 							<div class="alert alert-error" style="margin-bottom: 0.75rem;">{rejectError}</div>
 						{/if}
 						<div class="form-group" style="margin-bottom: 0.75rem;">
-							<label for="reject-reason" style="font-weight: 600; font-size: 0.9rem;">Reason for rejection <span style="color: #991b1b;">*</span></label>
+							<label for="reject-reason" style="font-weight: 600; font-size: 0.9rem;">Reason for declining <span style="color: #991b1b;">*</span></label>
 							<textarea
 								id="reject-reason"
 								bind:value={rejectReason}
@@ -425,7 +424,58 @@
 								onclick={handleRejectOffer}
 								disabled={rejectLoading}
 							>
-								{rejectLoading ? 'Rejecting…' : 'Confirm Rejection'}
+								{rejectLoading ? 'Declining…' : 'Confirm Decline'}
+							</button>
+							<button
+								class="btn"
+								onclick={() => { showRejectForm = false; rejectReason = ''; rejectError = ''; }}
+								disabled={rejectLoading}
+							>
+								Cancel
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+
+		<!-- Decline job (handler only, during SOW_NEGOTIATION) -->
+		{#if job.status === 'SOW_NEGOTIATION' && isHandler}
+			<div class="card" style="margin-bottom: 1.5rem; border-color: #fca5a5; background: #fff5f5;">
+				<h3 style="margin: 0 0 0.5rem; font-size: 1rem;">Decline Job</h3>
+				<p style="margin: 0 0 1rem; color: #555; font-size: 0.9rem;">If you no longer wish to proceed, you can decline this job and return it to open status.</p>
+
+				{#if !showRejectForm}
+					<button
+						class="btn btn-secondary"
+						style="color: #991b1b; border-color: #fca5a5;"
+						onclick={() => { showRejectForm = true; rejectError = ''; }}
+					>
+						Decline Job
+					</button>
+				{:else}
+					<div>
+						{#if rejectError}
+							<div class="alert alert-error" style="margin-bottom: 0.75rem;">{rejectError}</div>
+						{/if}
+						<div class="form-group" style="margin-bottom: 0.75rem;">
+							<label for="reject-reason-sow" style="font-weight: 600; font-size: 0.9rem;">Reason for declining <span style="color: #991b1b;">*</span></label>
+							<textarea
+								id="reject-reason-sow"
+								bind:value={rejectReason}
+								placeholder="Please explain why you are declining this job. This message will be sent to the employer."
+								style="min-height: 80px; margin-top: 0.35rem;"
+							></textarea>
+						</div>
+						<div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
+							<button
+								class="btn btn-secondary"
+								style="color: #991b1b; border-color: #fca5a5;"
+								onclick={handleRejectOffer}
+								disabled={rejectLoading}
+							>
+								{rejectLoading ? 'Declining…' : 'Confirm Decline'}
 							</button>
 							<button
 								class="btn"

--- a/frontend/src/routes/transactions/+page.svelte
+++ b/frontend/src/routes/transactions/+page.svelte
@@ -25,7 +25,7 @@
 			job_id: '00000000-0000-0000-0000-000000000001',
 			title: 'Build a REST API endpoint for user authentication',
 			status: 'COMPLETED',
-			total_payout: 15000,
+			total_payout: 150.00,
 			stripe_payment_intent: 'pi_sample_abc123',
 			created_at: '2026-03-20T14:32:00Z',
 			updated_at: '2026-03-21T09:15:00Z'
@@ -34,7 +34,7 @@
 			job_id: '00000000-0000-0000-0000-000000000002',
 			title: 'Write unit tests for the payment module',
 			status: 'IN_PROGRESS',
-			total_payout: 8500,
+			total_payout: 85.00,
 			stripe_payment_intent: undefined,
 			created_at: '2026-03-23T10:00:00Z',
 			updated_at: '2026-03-23T10:00:00Z'
@@ -48,6 +48,13 @@
 			style: 'currency',
 			currency: 'USD'
 		}).format(cents / 100);
+	}
+
+	function formatDollars(dollars: number): string {
+		return new Intl.NumberFormat('en-US', {
+			style: 'currency',
+			currency: 'USD'
+		}).format(dollars);
 	}
 
 	function formatDate(dateStr: string): string {
@@ -167,7 +174,7 @@
 								{tx.title}
 							</td>
 							<td style="font-variant-numeric: tabular-nums; font-weight: 500;">
-								{formatCents(tx.total_payout)}
+								{formatDollars(tx.total_payout)}
 							</td>
 							<td>
 								<span class="badge {statusBadgeClass(tx.status)}">{statusLabel(tx.status)}</span>
@@ -207,7 +214,7 @@
 								{/if}
 							</td>
 							<td style="font-variant-numeric: tabular-nums; font-weight: 500;">
-								{formatCents(tx.total_payout)}
+								{formatDollars(tx.total_payout)}
 							</td>
 							<td>
 								<span class="badge {statusBadgeClass(tx.status)}">{statusLabel(tx.status)}</span>


### PR DESCRIPTION
## Summary
- **#81**: Transactions page was dividing `total_payout` by 100 (treating dollars as cents). Added `formatDollars()` function that displays the value directly.
- **#82**: Removed `RETRACTED` status — retracted offers now revert to `UNASSIGNED`. Cleaned up CHECK constraints, badge maps, and tests.
- **#84**: After declining a job offer, the agent is now redirected to `/dashboard/handler` instead of staying on the job page.
- **#85**: Changed all "Reject" UI text to "Decline" (buttons, labels, prompts) for friendlier wording.
- **#86**: Added a "Decline Job" button during `SOW_NEGOTIATION` phase so agents can back out if negotiations fail.
- **#87**: Notification emails now link to the correct role-based dashboard (`/dashboard/handler` or `/dashboard/employer`) instead of the non-existent `/dashboard` route.

## Files changed
- `backend/notifications.go` — fetch user role, build role-specific dashboard link
- `backend/jobs.go` — retract sets UNASSIGNED instead of RETRACTED
- `backend/db.go` — remove RETRACTED from CHECK constraints
- `backend/jobs_test.go` — update test assertions
- `frontend/src/routes/jobs/[job_id]/+page.svelte` — Decline wording, redirect, SOW decline button
- `frontend/src/routes/dashboard/employer/+page.svelte` — remove RETRACTED badge
- `frontend/src/routes/transactions/+page.svelte` — fix dollars display

## Test plan
- [ ] Verify transactions page shows correct dollar amounts
- [ ] Retract an offer and confirm job goes to UNASSIGNED (not RETRACTED)
- [ ] Decline a job offer → confirm redirect to handler dashboard
- [ ] Check all reject buttons now say "Decline"
- [ ] During SOW negotiation, verify Decline Job button appears for agent
- [ ] Trigger a notification email and verify link goes to correct dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)