### PR TITLE
Fix #100: Move SoW button under box and update labels

### DIFF
--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -388,7 +388,6 @@
 			{#if isEmployer && (!job.agent_id || job.agent_id === '')}
 				<div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
 					<a href="/jobs/{jobId}/edit" class="btn btn-secondary" style="white-space: nowrap;">Edit Brief</a>
-					<a href="/jobs/{jobId}/sow/edit" class="btn btn-secondary" style="white-space: nowrap;">Set up SoW</a>
 					{#if job.status === 'UNASSIGNED'}
 						<a href="/" class="btn btn-secondary" style="white-space: nowrap;">Submit to Agent</a>
 					{/if}
@@ -665,6 +664,15 @@
 				milestones={job.milestones}
 				onUpdate={handleSowUpdate}
 			/>
+		{/if}
+
+		<!-- SoW button — shown to employer when job has no agent assigned yet -->
+		{#if isEmployer && (!job.agent_id || job.agent_id === '')}
+			<div style="margin-bottom: 1.5rem;">
+				<a href="/jobs/{jobId}/sow/edit" class="btn btn-secondary" style="white-space: nowrap;">
+					{job.sow ? 'Edit the Statement of Work' : 'Set up the Statement of Work'}
+				</a>
+			</div>
 		{/if}
 
 		<!-- Delivery section — shown from IN_PROGRESS onward -->


### PR DESCRIPTION
## Summary

- Removes the "Set up SoW" button from the job header action group (where it sat next to the job title)
- Adds the button below the SoW component section, keeping it contextually close to the SoW content
- Uses dynamic label: **"Set up the Statement of Work"** when no SoW exists, **"Edit the Statement of Work"** when one already exists

## Changes

Single file changed: `frontend/src/routes/jobs/[job_id]/+page.svelte`

- Removed old static `Set up SoW` anchor from the header button group
- Added new anchor below the `<SOW>` component block, inside an `{#if isEmployer && (!job.agent_id || job.agent_id === '')}` guard (same condition as before)

## Test plan

- [ ] As employer with no agent assigned: job page shows "Set up the Statement of Work" button below the SoW area
- [ ] After a SoW is created: button label changes to "Edit the Statement of Work"
- [ ] Button is NOT visible when a job has an agent assigned
- [ ] Header action group no longer contains the SoW button

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)