### PR TITLE
fix: resolve issues #102 #103 #104 #105

### DIFF
--- a/backend/db.go
+++ b/backend/db.go
@@ -169,6 +169,8 @@ var migrations = []func(tx *sql.Tx) error{
 				status TEXT NOT NULL DEFAULT 'PENDING' CHECK(status IN ('PENDING','REVIEW_REQUESTED','APPROVED','PAID')),
 				proof_of_work_url TEXT DEFAULT '',
 				proof_of_work_notes TEXT DEFAULT '',
+				stripe_checkout_session_id TEXT DEFAULT '',
+				stripe_payment_intent TEXT DEFAULT '',
 				created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 				updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 			)`,
@@ -352,6 +354,22 @@ var migrations = []func(tx *sql.Tx) error{
 		if _, err := tx.Exec(`ALTER TABLE jobs ADD COLUMN current_milestone_id TEXT REFERENCES milestones(id)`); err != nil {
 			if !strings.Contains(err.Error(), "duplicate column name") {
 				return fmt.Errorf("migration 10→11: add current_milestone_id to jobs: %w", err)
+			}
+		}
+		return nil
+	},
+
+	// version 11 → 12: Issue #102 — add stripe_checkout_session_id and stripe_payment_intent
+	// to milestones table. These columns are required by loadMilestonesForJob in jobs.go.
+	func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`ALTER TABLE milestones ADD COLUMN stripe_checkout_session_id TEXT DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("migration 11→12: add stripe_checkout_session_id to milestones: %w", err)
+			}
+		}
+		if _, err := tx.Exec(`ALTER TABLE milestones ADD COLUMN stripe_payment_intent TEXT DEFAULT ''`); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("migration 11→12: add stripe_payment_intent to milestones: %w", err)
 			}
 		}
 		return nil
@@ -573,6 +591,8 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 					status TEXT NOT NULL DEFAULT 'PENDING' CHECK(status IN ('PENDING','REVIEW_REQUESTED','APPROVED','PAID')),
 					proof_of_work_url TEXT DEFAULT '',
 					proof_of_work_notes TEXT DEFAULT '',
+					stripe_checkout_session_id TEXT DEFAULT '',
+					stripe_payment_intent TEXT DEFAULT '',
 					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
 					updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
 				)`,
@@ -581,6 +601,7 @@ var rawMigrations = map[int]func(db *sql.DB) error{
 				`INSERT INTO milestones_new
 				 SELECT m.id, s.id, m.title, m.amount, m.order_index, m.deliverables,
 				        m.status, m.proof_of_work_url, m.proof_of_work_notes,
+				        '', '',
 				        m.created_at, m.updated_at
 				 FROM milestones m
 				 JOIN sow s ON s.job_id = m.job_id`,

--- a/backend/email.go
+++ b/backend/email.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 )
 
 type resendEmailRequest struct {
@@ -16,9 +17,16 @@ type resendEmailRequest struct {
 }
 
 // SendEmail sends an email via the Resend API.
+// If apiKey starts with "test-", the call is a no-op so that unit tests never
+// hit the real Resend API (which would return 401 for fake keys).
 func SendEmail(apiKey, to, subject, htmlBody string) error {
 	if apiKey == "" {
 		return fmt.Errorf("RESEND_API_KEY not configured")
+	}
+
+	if strings.HasPrefix(apiKey, "test-") {
+		slog.Info("email skipped (test mode)", "to", to, "subject", subject)
+		return nil
 	}
 
 	slog.Info("sending email", "to", to, "subject", subject)

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -839,7 +839,7 @@ func (app *App) DeclineJobHandler(w http.ResponseWriter, r *http.Request) {
 
 	result, err := app.DB.Exec(
 		`UPDATE jobs SET status = 'UNASSIGNED', agent_id = NULL, updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND agent_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		 WHERE id = ? AND agent_id = ? AND status IN ('PENDING_ACCEPTANCE', 'SOW_NEGOTIATION')`,
 		jobID, agentID,
 	)
 	if err != nil {
@@ -850,7 +850,7 @@ func (app *App) DeclineJobHandler(w http.ResponseWriter, r *http.Request) {
 
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
-		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		writeError(w, http.StatusNotFound, "job not found or not in a declinable status")
 		return
 	}
 

--- a/frontend/src/routes/jobs/[job_id]/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/edit/+page.svelte
@@ -39,6 +39,8 @@
 	let timeline = $state('');
 	let sowLink = $state('');
 
+	let hasSow = $state(false);
+
 	let loading = $state(true);
 	let submitting = $state(false);
 	let error = $state('');
@@ -78,6 +80,7 @@
 			payout = job.total_payout ?? 0;
 			timeline = job.timeline_days ? String(job.timeline_days) : '';
 			sowLink = job.sow_link ?? '';
+			hasSow = !!job.sow;
 		} catch (e: unknown) {
 			loadError = e instanceof Error ? e.message : 'Failed to load job';
 		} finally {
@@ -189,7 +192,7 @@
 					<label for="sow-link">Link to SoW (optional)</label>
 					<input id="sow-link" type="url" bind:value={sowLink} placeholder="https://docs.example.com/sow" />
 				</div>
-				<a href="/jobs/{jobId}/sow/edit" class="btn btn-secondary" style="font-size: 0.9rem;">Pre-fill SoW →</a>
+				<a href="/jobs/{jobId}/sow/edit" class="btn btn-secondary" style="font-size: 0.9rem;">{hasSow ? 'Edit SoW →' : 'Pre-fill SoW →'}</a>
 			</div>
 
 			{#if deleteError}


### PR DESCRIPTION
## Summary

- **#102 (deploy blocker)**: Added `stripe_checkout_session_id` and `stripe_payment_intent` columns to the `milestones` table in three places: the initial CREATE TABLE (migration 0→1), the `milestones_new` rebuild (migration 7→8 with empty-string backfill), and a new migration 11→12 via `ALTER TABLE` for existing databases.
- **#103 (test email 401)**: `SendEmail` now returns early without making an HTTP call when the API key starts with `"test-"`. The existing test helper already sets `ResendAPIKey` to `"test-resend-key"`, so no test file changes were needed.
- **#104 (button label)**: In `frontend/src/routes/jobs/[job_id]/edit/+page.svelte`, added a `hasSow` state variable populated from `job.sow` on load. The SoW navigation button now renders "Edit SoW →" when a SoW exists and "Pre-fill SoW →" when it doesn't.
- **#105 (agent decline during negotiation)**: `DeclineJobHandler` now accepts jobs in `SOW_NEGOTIATION` status in addition to `PENDING_ACCEPTANCE`, so agents can decline after negotiation has started.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test ./... -count=1 -timeout 60s` passes — all tests green (verified locally)
- [ ] Deploy to staging and confirm milestones load without SQL error (#102)
- [ ] Confirm no Resend 401 errors appear in test output (#103)
- [ ] Open the edit page for a job with an existing SoW — button should read "Edit SoW →"; without a SoW it should read "Pre-fill SoW →" (#104)
- [ ] As an agent in SOW_NEGOTIATION, call `POST /api/v1/jobs/{id}/decline` — should return 200 (#105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)