### PR TITLE
fix: enable agent deliveries (#107)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1001,6 +1001,81 @@ func (app *App) DeliverJobHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(j)
 }
 
+// UIDeliverJobHandler allows an AGENT_MANAGER to submit a delivery via the UI (JWT auth).
+// This mirrors DeliverJobHandler (which uses API key auth) but is called from the web frontend.
+// POST /api/ui/jobs/{job_id}/deliver
+func (app *App) UIDeliverJobHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "ui_deliver_job")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "AGENT_MANAGER" {
+		log.Warn("authz failure: deliver job requires AGENT_MANAGER role", "role", role)
+		writeError(w, http.StatusForbidden, "only AGENT_MANAGER role can submit deliveries")
+		return
+	}
+
+	managerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "job_id")
+
+	// Verify the job belongs to one of this manager's agents and is in progress.
+	var agentID string
+	err := app.DB.QueryRow(
+		`SELECT j.agent_id FROM jobs j
+		   JOIN agents a ON j.agent_id = a.id
+		  WHERE j.id = ? AND a.manager_id = ? AND j.status = 'IN_PROGRESS'`,
+		jobID, managerID,
+	).Scan(&agentID)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found or not in IN_PROGRESS status")
+		return
+	}
+	if err != nil {
+		log.Error("ui deliver job: db error", "job_id", jobID, "manager_id", managerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	var req DeliverJobRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	result, err := app.DB.Exec(
+		`UPDATE jobs SET status = 'DELIVERED', delivery_notes = ?, delivery_url = ?, delivered_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND agent_id = ? AND status = 'IN_PROGRESS'`,
+		req.DeliveryNotes, req.DeliveryURL, jobID, agentID,
+	)
+	if err != nil {
+		log.Error("ui deliver job: database error", "job_id", jobID, "manager_id", managerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusNotFound, "job not found or not in IN_PROGRESS status")
+		return
+	}
+
+	log.Info("job delivered via UI", "job_id", jobID, "manager_id", managerID, "delivery_url", req.DeliveryURL)
+
+	j, err := app.getJobDetail(jobID)
+	if err != nil {
+		log.Error("ui deliver job: failed to retrieve after update", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve job")
+		return
+	}
+
+	// Notify employer that job was delivered
+	_ = app.CreateNotification(j.EmployerID, jobID, NotifMilestoneDelivered,
+		"Job delivered: "+j.Title,
+		"The agent has delivered the job. Please review and approve or request a revision.")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(j)
+}
+
 // ApproveDeliveryHandler captures the Stripe payment and completes the job (employer JWT auth).
 // POST /api/ui/jobs/{job_id}/approve-delivery
 func (app *App) ApproveDeliveryHandler(w http.ResponseWriter, r *http.Request) {

--- a/backend/router.go
+++ b/backend/router.go
@@ -129,7 +129,8 @@ func NewRouter(app *App) *chi.Mux {
 				r.Post("/{id}/accept", app.UIAcceptJobHandler)
 				r.Post("/{id}/reject", app.UIRejectJobHandler)
 				r.Post("/{id}/retract", app.RetractOfferHandler)
-				r.Post("/{job_id}/approve-delivery", app.ApproveDeliveryHandler)
+				r.Post("/{job_id}/deliver", app.UIDeliverJobHandler)
+			r.Post("/{job_id}/approve-delivery", app.ApproveDeliveryHandler)
 				r.Post("/{job_id}/request-revision", app.RequestRevisionHandler)
 			})
 

--- a/frontend/src/lib/components/DeliverySection.svelte
+++ b/frontend/src/lib/components/DeliverySection.svelte
@@ -10,11 +10,10 @@
 		jobId: string;
 		jobStatus: string;
 		delivery?: DeliveryData | null;
-		agentApiKey?: string;
 		onUpdate?: () => void;
 	}
 
-	let { jobId, jobStatus, delivery = null, agentApiKey = '', onUpdate }: Props = $props();
+	let { jobId, jobStatus, delivery = null, onUpdate }: Props = $props();
 
 	let deliveryNotes = $state('');
 	let deliveryUrl = $state('');
@@ -32,13 +31,8 @@
 		error = '';
 		successMsg = '';
 		try {
-			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-			if (agentApiKey) {
-				headers['X-API-Key'] = agentApiKey;
-			}
-			const res = await fetch(`/api/v1/jobs/${jobId}/deliver`, {
+			const res = await apiFetch(`/api/ui/jobs/${jobId}/deliver`, {
 				method: 'POST',
-				headers,
 				body: JSON.stringify({
 					delivery_notes: deliveryNotes,
 					delivery_url: deliveryUrl || undefined


### PR DESCRIPTION
Fixes #107 - Agent unable to make deliveries

## Root Cause

`DeliverySection.svelte` was calling `POST /api/v1/jobs/{job_id}/deliver` with an `X-API-Key` header. That endpoint sits behind `APIKeyAuth` middleware. The frontend has no agent API key — it uses JWT cookies for all other requests — so every delivery attempt returned `"missing or invalid Authorization header"`.

## Fix

**Backend** (`backend/jobs.go`): Added `UIDeliverJobHandler` — mirrors the existing `DeliverJobHandler` but uses JWT auth. Verifies the caller has `AGENT_MANAGER` role and that the job's agent belongs to them via a `JOIN agents ON manager_id` check.

**Backend** (`backend/router.go`): Registered `POST /api/ui/jobs/{job_id}/deliver` in the JWT-protected route group.

**Frontend** (`frontend/src/lib/components/DeliverySection.svelte`): Replaced the raw `fetch` + `X-API-Key` pattern with `apiFetch` against `/api/ui/jobs/${jobId}/deliver`, consistent with all other frontend API calls. Removed the now-unused `agentApiKey` prop.

## Testing

- `go test ./...` passes
- `go build ./...` clean