### PR TITLE
fix #108: correct milestone dollar/cents display bugs

### DIFF
--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -695,7 +695,7 @@
 							<div class="milestone-header">
 								<strong style="font-size: 0.95rem;">{milestone.title}</strong>
 								<div style="display: flex; align-items: center; gap: 0.75rem;">
-									<span style="font-size: 0.9rem; color: #555;">${(milestone.amount / 100).toFixed(2)}</span>
+									<span style="font-size: 0.9rem; color: #555;">${milestone.amount.toFixed(2)}</span>
 									<span class="badge {milestone.status === 'COMPLETED' ? 'badge-completed' : 'badge-pending'}">
 										{statusLabel(milestone.status)}
 									</span>

--- a/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
@@ -125,7 +125,7 @@
 				// No SoW yet — pre-populate from Job Brief data
 				editDetailedSpec = '';
 				editWorkProcess = '';
-				editPriceDollars = job ? (job.total_payout / 100).toFixed(2) : '';
+				editPriceDollars = job ? String(job.total_payout) : '';
 				editTimelineDays = job?.timeline_days ? String(job.timeline_days) : '';
 			}
 


### PR DESCRIPTION
## Summary

Fixes two places where milestone `amount` (stored as integer dollars) was erroneously divided by 100, causing amounts like \$11 to display as \$0.11.

- **`sow/edit/+page.svelte`**: when no SoW exists yet, the price field was pre-populated with `(job.total_payout / 100).toFixed(2)`. Since `total_payout` is already stored in dollars, this divided twice, producing $0.11 instead of $11.00. Fixed to use `String(job.total_payout)`.
- **`jobs/[job_id]/+page.svelte`**: the Milestone Progress read-only section showed `(milestone.amount / 100).toFixed(2)` — same bug. Fixed to `milestone.amount.toFixed(2)`.

Both `total_payout` and `milestones.amount` are integer dollar values in the DB (not cents). The SoW `price_cents` field *is* in cents and was already handled correctly everywhere else.

## Test plan
- [ ] Create a job with Total Payout = 100
- [ ] Enter SoW negotiation; open Edit SoW — price field should pre-fill as 100.00, not 1.00
- [ ] Add a milestone with payout = 50; complete the job
- [ ] Milestone Progress section should show $50.00, not $0.50

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)