### PR TITLE
fix #109: remove redundant price/timeline from Job Brief in SoW view

### DIFF
--- a/frontend/src/lib/components/SOW.svelte
+++ b/frontend/src/lib/components/SOW.svelte
@@ -284,18 +284,6 @@
 				<p style="margin: 0; color: #333; white-space: pre-wrap;">{jobSummary.description}</p>
 			</div>
 		{/if}
-		<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;">
-			<div>
-				<p style="font-size: 0.85rem; font-weight: 600; color: #555; margin: 0 0 0.2rem; text-transform: uppercase; letter-spacing: 0.04em;">Total Payout</p>
-				<p style="margin: 0; font-size: 1.05rem; font-weight: 600;">${jobSummary.total_payout.toFixed(2)}</p>
-			</div>
-			{#if jobSummary.timeline_days}
-				<div>
-					<p style="font-size: 0.85rem; font-weight: 600; color: #555; margin: 0 0 0.2rem; text-transform: uppercase; letter-spacing: 0.04em;">Timeline</p>
-					<p style="margin: 0;">{jobSummary.timeline_days} day{jobSummary.timeline_days !== 1 ? 's' : ''}</p>
-				</div>
-			{/if}
-		</div>
 		{#if jobSummary.sow_link}
 			<div>
 				<p style="font-size: 0.85rem; font-weight: 600; color: #555; margin: 0 0 0.2rem; text-transform: uppercase; letter-spacing: 0.04em;">SoW Reference</p>

--- a/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
@@ -125,7 +125,7 @@
 				// No SoW yet — pre-populate from Job Brief data
 				editDetailedSpec = '';
 				editWorkProcess = '';
-				editPriceDollars = job ? (job.total_payout / 100).toFixed(2) : '';
+				editPriceDollars = job ? String(job.total_payout) : '';
 				editTimelineDays = job?.timeline_days ? String(job.timeline_days) : '';
 			}
 


### PR DESCRIPTION
## Summary

- Removes the "Total Payout" and "Timeline" fields from the Job Brief card inside the SOW component. The SoW itself already shows price and timeline, so displaying them twice (with slightly different labels) was confusing during negotiation.
- Fixes the SoW edit pre-fill bug: when entering SoW negotiation with no existing SoW, the price field now correctly pre-populates from `job.total_payout` (integer dollars) instead of dividing by 100, which caused $11 to appear as $0.11.

The Job Brief card still shows: title, description, and SoW reference link — contextual info that isn't duplicated by the SoW.

## Test plan
- [ ] Create a job → assign agent → enter SOW_NEGOTIATION
- [ ] Open SoW view: Job Brief card should show title and description, but NOT price or timeline
- [ ] Click "Edit SoW" with no existing SoW: price field should pre-fill as the Job Brief total payout (e.g. 100, not 1.00)
- [ ] Confirm SoW section still shows price and timeline once the SoW is saved

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)