### PR TITLE
fix #110: make milestones optional in SoW

### DIFF
--- a/frontend/src/lib/components/SOW.svelte
+++ b/frontend/src/lib/components/SOW.svelte
@@ -115,7 +115,7 @@
 					: ['']
 			}));
 		} else {
-			editMilestones = [{ title: '', payout: 0, deliverables: '', criteria: [''] }];
+			editMilestones = [];
 		}
 		editing = true;
 		error = '';
@@ -378,11 +378,9 @@
 					<div class="milestone-row">
 						<div class="milestone-header">
 							<strong style="font-size: 0.9rem;">Milestone {i + 1}</strong>
-							{#if editMilestones.length > 1}
-								<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
-									Remove
-								</button>
-							{/if}
+							<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
+								Remove
+							</button>
 						</div>
 
 						<div style="display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; align-items: start;">

--- a/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
@@ -140,7 +140,7 @@
 						: ['']
 				}));
 			} else {
-				editMilestones = [{ title: '', payout: 0, deliverables: '', criteria: [''] }];
+				editMilestones = [];
 			}
 		} catch (e: unknown) {
 			loadError = e instanceof Error ? e.message : 'Failed to load job';
@@ -345,11 +345,9 @@
 					<div class="milestone-row">
 						<div class="milestone-header">
 							<strong style="font-size: 0.9rem;">Milestone {i + 1}</strong>
-							{#if editMilestones.length > 1}
-								<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
-									Remove
-								</button>
-							{/if}
+							<button type="button" class="btn btn-danger" onclick={() => removeMilestone(i)} style="font-size: 0.8rem; padding: 0.2rem 0.6rem;">
+								Remove
+							</button>
 						</div>
 
 						<div style="display: grid; grid-template-columns: 1fr auto; gap: 0.75rem; align-items: start;">


### PR DESCRIPTION
## Summary

- SoW edit form (both SOW.svelte inline and sow/edit/+page.svelte) now starts with an **empty milestones list** instead of one pre-filled empty milestone.
- The "Remove" button is now always shown, including the last remaining milestone, so users can clear all milestones for a simple job.
- No backend changes needed: when `milestones: []` is sent, Go decodes it as an empty (non-nil) slice, which causes existing milestones to be deleted and no new ones inserted.
- When no milestones exist, the payment flow falls back to the full SoW `price_cents` (already handled in `stripe.go` and `getPaymentAmountCents` in the frontend).

## Test plan
- [ ] Open SoW edit form — milestones section should be empty with just the "+ Add milestone" button
- [ ] Save a SoW with no milestones — should succeed
- [ ] After accepting a milestone-free SoW, the employer should be prompted to pay the full SoW price
- [ ] Add 1 milestone, then click Remove — milestone is removed and form can be saved with zero milestones
- [ ] Existing flows with milestones are unaffected

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)