### PR TITLE
fix: allow UIRejectJobHandler to decline jobs in SOW_NEGOTIATION (#105 follow-up)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1291,17 +1291,20 @@ func (app *App) UIRejectJobHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the job belongs to one of this manager's agents and is awaiting acceptance.
+	// Verify the job belongs to one of this manager's agents and is in a declinable status.
+	// Decline is permitted during PENDING_ACCEPTANCE (offer not yet accepted) and
+	// SOW_NEGOTIATION (negotiation in progress), matching the UI which shows the decline
+	// action in both states.
 	var agentID string
 	err := app.DB.QueryRow(
 		`SELECT j.agent_id
 		   FROM jobs j
 		   JOIN agents a ON j.agent_id = a.id
-		  WHERE j.id = ? AND a.manager_id = ? AND j.status = 'PENDING_ACCEPTANCE'`,
+		  WHERE j.id = ? AND a.manager_id = ? AND j.status IN ('PENDING_ACCEPTANCE', 'SOW_NEGOTIATION')`,
 		jobID, managerID,
 	).Scan(&agentID)
 	if err == sql.ErrNoRows {
-		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE or SOW_NEGOTIATION status")
 		return
 	}
 	if err != nil {
@@ -1313,7 +1316,7 @@ func (app *App) UIRejectJobHandler(w http.ResponseWriter, r *http.Request) {
 	// Reset the job to UNASSIGNED, clearing the agent assignment.
 	result, err := app.DB.Exec(
 		`UPDATE jobs SET status = 'UNASSIGNED', agent_id = NULL, updated_at = CURRENT_TIMESTAMP
-		  WHERE id = ? AND agent_id = ? AND status = 'PENDING_ACCEPTANCE'`,
+		  WHERE id = ? AND agent_id = ? AND status IN ('PENDING_ACCEPTANCE', 'SOW_NEGOTIATION')`,
 		jobID, agentID,
 	)
 	if err != nil {
@@ -1323,7 +1326,7 @@ func (app *App) UIRejectJobHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
-		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE status")
+		writeError(w, http.StatusNotFound, "job not found or not in PENDING_ACCEPTANCE or SOW_NEGOTIATION status")
 		return
 	}
 

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -374,6 +374,58 @@ func TestRetractOfferDuringSowNegotiation(t *testing.T) {
 	}
 }
 
+// TestUIRejectJobDuringSowNegotiation verifies that an AGENT_MANAGER can reject (decline)
+// a job via the UI endpoint while the job is in SOW_NEGOTIATION status.
+// This is the regression case from issue #105: PR #106 fixed DeclineJobHandler (agent API-key
+// path) but UIRejectJobHandler still blocked the request with "not in PENDING_ACCEPTANCE status".
+func TestUIRejectJobDuringSowNegotiation(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, managerID, agentID, apiKey := setupJobFixtures(t, app)
+	employerToken := makeAuthToken(t, app, employerID, "EMPLOYER")
+	managerToken := makeAuthToken(t, app, managerID, "AGENT_MANAGER")
+
+	// Create job offer (PENDING_ACCEPTANCE) and have the agent accept it (SOW_NEGOTIATION).
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire",
+		HireRequest{AgentID: agentID, Title: "Sow negotiation decline test", TotalPayout: 400, TimelineDays: 3},
+		employerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("hire: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+
+	rr = doRequest(t, router, http.MethodPost, "/api/v1/jobs/"+job.ID+"/accept", nil, apiKey)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("accept: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify job is now in SOW_NEGOTIATION.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+job.ID, nil, employerToken)
+	var updated Job
+	json.Unmarshal(rr.Body.Bytes(), &updated)
+	if updated.Status != "SOW_NEGOTIATION" {
+		t.Fatalf("expected SOW_NEGOTIATION, got %q", updated.Status)
+	}
+
+	// Manager declines during SOW_NEGOTIATION via the UI reject endpoint — must succeed.
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+job.ID+"/reject",
+		map[string]string{"reason": "scope too large"}, managerToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ui reject during SOW_NEGOTIATION: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var rejected Job
+	json.Unmarshal(rr.Body.Bytes(), &rejected)
+	if rejected.Status != "UNASSIGNED" {
+		t.Errorf("expected UNASSIGNED after decline, got %q", rejected.Status)
+	}
+	if rejected.AgentID != "" {
+		t.Errorf("expected agent_id cleared after decline, got %q", rejected.AgentID)
+	}
+}
+
 // TestRetractOfferFinalContract verifies that retraction is blocked once the contract is
 // final (IN_PROGRESS and beyond — i.e. after payment has been captured).
 func TestRetractOfferFinalContract(t *testing.T) {


### PR DESCRIPTION
## Root cause

PR #106 fixed `DeclineJobHandler` (the agent API-key endpoint `POST /api/v1/jobs/{id}/decline`) to accept both `PENDING_ACCEPTANCE` and `SOW_NEGOTIATION` status. However, there is a **second, separate decline handler** used by the browser UI:

**`UIRejectJobHandler`** — `POST /api/ui/jobs/{id}/reject` (AGENT_MANAGER JWT auth)

This handler was **not updated in #106** and still enforced `status = 'PENDING_ACCEPTANCE'` in both its SELECT verification query (line 1300) and its UPDATE statement (line 1316). When an AGENT_MANAGER clicked "Decline Job" during SOW_NEGOTIATION, the frontend sent the request to `/api/ui/jobs/{id}/reject`, which hit this handler and returned the "job not found or not in PENDING_ACCEPTANCE status" error Tom reported at 06:37 UTC.

The frontend correctly renders the decline UI for both `PENDING_ACCEPTANCE` and `SOW_NEGOTIATION` states (see `+page.svelte` lines 452 and 517), making this a pure backend oversight.

## Fix

Both SQL queries in `UIRejectJobHandler` updated from `status = 'PENDING_ACCEPTANCE'` to `status IN ('PENDING_ACCEPTANCE', 'SOW_NEGOTIATION')`, matching the fix already applied in #106 to the other handler.

## Test

Added `TestUIRejectJobDuringSowNegotiation` which reproduces the exact failure path:
1. Hire agent (job → `PENDING_ACCEPTANCE`)
2. Agent accepts (job → `SOW_NEGOTIATION`)
3. Manager calls `POST /api/ui/jobs/{id}/reject` → must return 200 and reset job to `UNASSIGNED`

This test would have caught the regression introduced by #106 not covering the UI path.

Closes #105