### PR TITLE
fix: capture per-milestone Stripe payment intents (#116)

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -619,29 +619,88 @@ func (app *App) ApproveMilestoneHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	result, err := app.DB.Exec(
-		`UPDATE milestones SET status = 'APPROVED', updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND sow_id = (SELECT id FROM sow WHERE job_id = ?) AND status = 'REVIEW_REQUESTED'`,
+	// Read the milestone's Stripe payment intent before we mutate status, so we
+	// can capture it atomically with the APPROVED→PAID transition. We also verify
+	// the milestone belongs to this job in the same query.
+	var milestoneStripeIntent sql.NullString
+	var milestoneCurrentStatus string
+	err = app.DB.QueryRow(
+		`SELECT m.stripe_payment_intent, m.status
+		 FROM milestones m
+		 WHERE m.id = ? AND m.sow_id = (SELECT id FROM sow WHERE job_id = ?)`,
 		milestoneID, jobID,
-	)
+	).Scan(&milestoneStripeIntent, &milestoneCurrentStatus)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "milestone not found for this job")
+		return
+	}
 	if err != nil {
-		log.Error("milestone approval failed: database error", "job_id", jobID, "milestone_id", milestoneID, "error", err)
+		log.Error("milestone approval: db error fetching milestone intent", "milestone_id", milestoneID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	if milestoneCurrentStatus != "REVIEW_REQUESTED" {
+		writeError(w, http.StatusBadRequest, "milestone not found or not in REVIEW_REQUESTED status")
+		return
+	}
+
+	// Capture the Stripe payment intent for this milestone BEFORE marking it PAID.
+	// Each milestone has its own intent (stored by the webhook handler), so
+	// intermediate milestones are captured here rather than waiting for delivery
+	// approval, which would only capture the final intent.
+	if milestoneStripeIntent.Valid && milestoneStripeIntent.String != "" {
+		stripe.Key = app.Config.StripeSecretKey
+		if _, stripeErr := paymentintent.Capture(milestoneStripeIntent.String, nil); stripeErr != nil {
+			log.Error("milestone approval: stripe capture failed", "job_id", jobID, "milestone_id", milestoneID,
+				"payment_intent", milestoneStripeIntent.String, "error", stripeErr)
+			writeError(w, http.StatusInternalServerError, fmt.Sprintf("failed to capture milestone payment: %v", stripeErr))
+			return
+		}
+		log.Info("milestone payment captured", "job_id", jobID, "milestone_id", milestoneID,
+			"payment_intent", milestoneStripeIntent.String)
+	}
+
+	// Atomically transition REVIEW_REQUESTED → APPROVED → PAID inside a single
+	// transaction so a partial failure cannot leave the milestone in APPROVED
+	// without being PAID (or vice-versa).
+	tx, err := app.DB.Begin()
+	if err != nil {
+		log.Error("milestone approval: failed to begin transaction", "error", err)
 		writeError(w, http.StatusInternalServerError, "database error")
 		return
 	}
 
+	result, err := tx.Exec(
+		`UPDATE milestones SET status = 'APPROVED', updated_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND status = 'REVIEW_REQUESTED'`,
+		milestoneID,
+	)
+	if err != nil {
+		_ = tx.Rollback()
+		log.Error("milestone approval failed: database error on APPROVED", "job_id", jobID, "milestone_id", milestoneID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
+		_ = tx.Rollback()
 		writeError(w, http.StatusBadRequest, "milestone not found or not in REVIEW_REQUESTED status")
 		return
 	}
 
 	// Mark the approved milestone as PAID (deliverables confirmed, payment is captured).
-	if _, err := app.DB.Exec(
+	if _, err := tx.Exec(
 		`UPDATE milestones SET status = 'PAID', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
 		milestoneID,
 	); err != nil {
+		_ = tx.Rollback()
 		log.Error("milestone approval: failed to mark milestone PAID", "milestone_id", milestoneID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Error("milestone approval: failed to commit transaction", "milestone_id", milestoneID, "error", err)
 		writeError(w, http.StatusInternalServerError, "database error")
 		return
 	}

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 )
 
+
 // setupJobFixtures creates a verified employer, an agent handler, an agent, and returns them.
 func setupJobFixtures(t *testing.T, app *App) (employerID, managerID, agentID, agentAPIKey string) {
 	t.Helper()
@@ -405,4 +406,133 @@ func TestRetractOfferFinalContract(t *testing.T) {
 	if rr.Code != http.StatusConflict {
 		t.Errorf("final contract retract: expected 409, got %d: %s", rr.Code, rr.Body.String())
 	}
+}
+
+// TestMilestoneLevelCapture verifies the per-milestone Stripe capture behaviour
+// introduced to fix the multi-milestone payment intent bug (issue #116).
+//
+// It tests two sub-cases:
+//
+//  1. When a milestone has a non-empty stripe_payment_intent, ApproveMilestoneHandler
+//     attempts to capture it. With no real Stripe key configured the capture call
+//     returns an error and the handler returns HTTP 500 — confirming the capture
+//     attempt is made and is not silently skipped.
+//
+//  2. When a milestone has no stripe_payment_intent (e.g. paid via coupon or not
+//     yet set by the webhook), ApproveMilestoneHandler succeeds (HTTP 200) and
+//     marks the milestone PAID without crashing.
+func TestMilestoneLevelCapture(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, managerID, agentID, agentAPIKey := setupJobFixtures(t, app)
+	employerTok := makeAuthToken(t, app, employerID, "EMPLOYER")
+
+	// --- Sub-case 1: milestone has a stripe_payment_intent —
+	// ApproveMilestoneHandler should attempt capture and return 500 (no Stripe key).
+	t.Run("attempts capture when intent present", func(t *testing.T) {
+		jobID, m1ID, _ := setupSowWithMilestones(t, app, router, employerID, managerID, agentID, agentAPIKey)
+
+		// Simulate the Stripe webhook: set job IN_PROGRESS and store a fake
+		// payment intent on milestone 1.
+		fakeIntentID := "pi_test_milestone_capture_123"
+		if _, err := app.DB.Exec(
+			`UPDATE jobs SET status = 'IN_PROGRESS', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobID,
+		); err != nil {
+			t.Fatalf("set job IN_PROGRESS: %v", err)
+		}
+		if _, err := app.DB.Exec(
+			`UPDATE milestones SET stripe_payment_intent = ? WHERE id = ?`, fakeIntentID, m1ID,
+		); err != nil {
+			t.Fatalf("set milestone intent: %v", err)
+		}
+
+		// Agent submits proof of work to move milestone 1 → REVIEW_REQUESTED.
+		submitBody := SubmitProofRequest{ProofOfWorkURL: "https://example.com/proof1", ProofOfWorkNotes: "Done"}
+		rr := doRequest(t, router, http.MethodPost,
+			"/api/v1/jobs/"+jobID+"/milestones/"+m1ID+"/submit", submitBody, agentAPIKey)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("submit proof: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		// Approve milestone 1. Because no real Stripe key is configured, the
+		// capture call will fail — we expect a 500 response. This confirms that
+		// ApproveMilestoneHandler actually attempted the capture (it did not
+		// skip it when the intent was present).
+		rr = doRequest(t, router, http.MethodPost,
+			"/api/ui/jobs/"+jobID+"/milestones/"+m1ID+"/approve", nil, employerTok)
+		if rr.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500 (Stripe capture attempted, no key configured), got %d: %s",
+				rr.Code, rr.Body.String())
+		}
+
+		// The milestone must NOT have been marked PAID (capture failed, so the
+		// DB transaction was never committed).
+		var status string
+		if err := app.DB.QueryRow(`SELECT status FROM milestones WHERE id = ?`, m1ID).Scan(&status); err != nil {
+			t.Fatalf("query milestone status: %v", err)
+		}
+		if status == "PAID" {
+			t.Error("milestone should not be PAID after failed Stripe capture")
+		}
+	})
+
+	// --- Sub-case 2: milestone has NO stripe_payment_intent —
+	// ApproveMilestoneHandler should skip capture and succeed (HTTP 200).
+	t.Run("succeeds without intent (no capture needed)", func(t *testing.T) {
+		// Build a fresh employer/agent setup so this sub-test is independent.
+		emp2ID, mgr2ID, ag2ID, ag2APIKey := setupJobFixtures(t, app)
+		emp2Tok := makeAuthToken(t, app, emp2ID, "EMPLOYER")
+
+		jobID, m1ID, _ := setupSowWithMilestones(t, app, router, emp2ID, mgr2ID, ag2ID, ag2APIKey)
+
+		// Simulate the webhook completing without storing an intent on the milestone
+		// (e.g. coupon path, or webhook ran before the fix).
+		if _, err := app.DB.Exec(
+			`UPDATE jobs SET status = 'IN_PROGRESS', updated_at = CURRENT_TIMESTAMP WHERE id = ?`, jobID,
+		); err != nil {
+			t.Fatalf("set job IN_PROGRESS: %v", err)
+		}
+		// Explicitly ensure stripe_payment_intent is empty (it is by default, but be explicit).
+		if _, err := app.DB.Exec(
+			`UPDATE milestones SET stripe_payment_intent = '' WHERE id = ?`, m1ID,
+		); err != nil {
+			t.Fatalf("clear milestone intent: %v", err)
+		}
+
+		// Agent submits proof → REVIEW_REQUESTED.
+		submitBody := SubmitProofRequest{ProofOfWorkURL: "https://example.com/proof2", ProofOfWorkNotes: "Done"}
+		rr := doRequest(t, router, http.MethodPost,
+			"/api/v1/jobs/"+jobID+"/milestones/"+m1ID+"/submit", submitBody, ag2APIKey)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("submit proof: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		// Approve milestone 1 — no Stripe intent, so capture is skipped and the
+		// handler must return 200.
+		rr = doRequest(t, router, http.MethodPost,
+			"/api/ui/jobs/"+jobID+"/milestones/"+m1ID+"/approve", nil, emp2Tok)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("approve milestone (no intent): expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+
+		// Milestone must be PAID.
+		var status string
+		if err := app.DB.QueryRow(`SELECT status FROM milestones WHERE id = ?`, m1ID).Scan(&status); err != nil {
+			t.Fatalf("query milestone status: %v", err)
+		}
+		if status != "PAID" {
+			t.Errorf("expected milestone status PAID, got %q", status)
+		}
+
+		// The response body should be the updated milestone.
+		var m Milestone
+		if err := json.Unmarshal(rr.Body.Bytes(), &m); err != nil {
+			t.Fatalf("decode milestone response: %v", err)
+		}
+		if m.Status != "PAID" {
+			t.Errorf("response milestone status: expected PAID, got %q", m.Status)
+		}
+	})
 }

--- a/backend/stripe.go
+++ b/backend/stripe.go
@@ -286,6 +286,22 @@ func (app *App) HandleStripeWebhook(w http.ResponseWriter, r *http.Request) {
 			paymentIntentID = cs.PaymentIntent.ID
 		}
 
+		// If this checkout session was for a specific milestone, store the payment
+		// intent on that milestone row so ApproveMilestoneHandler can capture it
+		// later. We do this before updating the job so the intent is persisted even
+		// if the job update races with another request.
+		if paymentIntentID != "" {
+			if _, milestoneErr := app.DB.Exec(
+				`UPDATE milestones SET stripe_payment_intent = ?, stripe_checkout_session_id = ?, updated_at = CURRENT_TIMESTAMP
+				 WHERE id = (SELECT current_milestone_id FROM jobs WHERE stripe_checkout_session_id = ?)
+				   AND stripe_payment_intent = ''`,
+				paymentIntentID, cs.ID, cs.ID,
+			); milestoneErr != nil {
+				log.Error("webhook: failed to store payment intent on milestone", "session_id", cs.ID, "error", milestoneErr)
+				// Non-fatal: log and continue — the job update below still moves the job to IN_PROGRESS.
+			}
+		}
+
 		result, err := app.DB.Exec(
 			`UPDATE jobs SET status = 'IN_PROGRESS', stripe_payment_intent = ?, updated_at = CURRENT_TIMESTAMP
 			 WHERE stripe_checkout_session_id = ? AND status = 'AWAITING_PAYMENT'`,


### PR DESCRIPTION
## Summary

Fixes #116. Intermediate milestone payment intents were being silently lost:

- Each milestone checkout created a `capture_method: manual` Stripe payment intent, but the ID was stored only in `jobs.stripe_payment_intent` — when milestone 2 was checked out, its intent overwrote milestone 1's.
- `ApproveMilestoneHandler` marked milestones PAID without ever calling Stripe capture.
- `ApproveDeliveryHandler` only captured the final (job-level) intent, so all intermediate milestone intents expired uncaptured after 7 days.

## Changes

**`backend/stripe.go` — webhook handler**
- When `checkout.session.completed` fires, also write the payment intent ID to `milestones.stripe_payment_intent` for the milestone identified by `jobs.current_milestone_id`. This gives each milestone its own intent record.

**`backend/jobs.go` — `ApproveMilestoneHandler`**
- Before transitioning status, read `milestones.stripe_payment_intent` for the milestone being approved.
- Call `paymentintent.Capture` for that intent before committing the DB changes. If capture fails, the request returns 500 and the milestone is NOT marked PAID (no money lost).
- Wrap the `REVIEW_REQUESTED → APPROVED → PAID` transition in a single DB transaction to prevent partial updates if something fails mid-flight.

**`backend/jobs_test.go` — `TestMilestoneLevelCapture`**
- Sub-case 1: milestone with a `stripe_payment_intent` → handler attempts capture → returns 500 (no Stripe key in test env), milestone stays un-PAID. Confirms capture is not silently skipped.
- Sub-case 2: milestone with empty `stripe_payment_intent` → capture is skipped, approval succeeds (200), milestone is PAID. Confirms backward compatibility with coupon/legacy paths.

## Test plan

- [x] `go test ./...` — all existing tests pass, new test passes
- [ ] Manual: create a 2-milestone job, pay for milestone 1, approve it — verify Stripe capture is called for milestone 1's intent (not milestone 2's)
- [ ] Manual: pay for milestone 2, approve delivery — verify milestone 2's intent is captured by `ApproveDeliveryHandler` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)