### PR TITLE
fix: bypass Stripe for $0 milestones

### DIFF
--- a/backend/stripe.go
+++ b/backend/stripe.go
@@ -106,6 +106,39 @@ func (app *App) CreateCheckoutHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// If the milestone amount is $0, skip Stripe entirely and advance the job.
+	if baseAmountCents == 0 && currentMilestoneID != "" {
+		if _, dbErr := app.DB.Exec(
+			`UPDATE milestones SET status = 'PAID', updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			currentMilestoneID,
+		); dbErr != nil {
+			log.Error("checkout: failed to mark $0 milestone PAID", "milestone_id", currentMilestoneID, "error", dbErr)
+			writeError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+		_, dbErr := app.DB.Exec(
+			`UPDATE jobs SET status = 'IN_PROGRESS', current_milestone_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
+			nullableString(currentMilestoneID), jobID,
+		)
+		if dbErr != nil {
+			log.Error("checkout: failed to update job to IN_PROGRESS for $0 milestone", "job_id", jobID, "error", dbErr)
+			writeError(w, http.StatusInternalServerError, "database error")
+			return
+		}
+		log.Info("checkout: $0 milestone bypassed Stripe, job moved to IN_PROGRESS", "job_id", jobID, "milestone_id", currentMilestoneID, "employer_id", employerID)
+
+		_ = app.CreateNotification(employerID, jobID, NotifPaymentDue,
+			"Milestone started",
+			fmt.Sprintf("Milestone %d is $0 — no payment required, job started", currentMilestoneNumber))
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"paid":    true,
+			"message": fmt.Sprintf("Milestone %d is $0 — no payment required", currentMilestoneNumber),
+		})
+		return
+	}
+
 	if baseAmountCents <= 0 {
 		writeError(w, http.StatusBadRequest, "charge amount must be greater than zero")
 		return


### PR DESCRIPTION
Closes #122

## Summary
- When a milestone has `amount = 0`, the checkout handler now skips Stripe entirely
- Marks the $0 milestone as PAID and advances the job to IN_PROGRESS directly
- Mirrors the existing full-coupon bypass logic (lines 147-182)
- Creates a notification informing the employer

## Why
A SoW with M1=$0 (e.g., setup milestone with no upfront cost) throws "charge amount must be greater than zero" when the employer tries to start the job. This blocks the entire transaction flow.

## Test plan
- [ ] Create a SoW with M1=$0, M2=$X, M3=$Y
- [ ] Click "Start Job" — should bypass Stripe, show "no payment required"
- [ ] Job should move to IN_PROGRESS
- [ ] First milestone should show PAID status