### PR TITLE
fix: move Add Milestone button to bottom of list

### DIFF
--- a/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/sow/edit/+page.svelte
@@ -322,12 +322,7 @@
 
 			<!-- Milestones section -->
 			<div class="card" style="margin-bottom: 1.5rem;">
-				<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-					<h2 style="margin: 0; font-size: 1.1rem;">Milestones</h2>
-					<button type="button" class="btn btn-secondary" onclick={addMilestone} style="font-size: 0.85rem; padding: 0.35rem 0.9rem;">
-						+ Add milestone
-					</button>
-				</div>
+				<h2 style="margin: 0 0 1rem; font-size: 1.1rem;">Milestones</h2>
 
 				<!-- Milestone totals summary -->
 				{#if editPriceDollars && parseFloat(editPriceDollars) > 0}
@@ -401,6 +396,10 @@
 						</div>
 					</div>
 				{/each}
+
+				<button type="button" class="btn btn-secondary" onclick={addMilestone} style="font-size: 0.85rem; padding: 0.35rem 0.9rem; margin-top: 0.5rem;">
+					+ Add milestone
+				</button>
 			</div>
 
 			<div style="display: flex; gap: 0.75rem; align-items: center;">


### PR DESCRIPTION
Closes #118

## Summary
- Moves the `+ Add milestone` button from the card header to below the last milestone
- Users no longer need to scroll back up after adding multiple milestones
- Button sits above the "Save SoW" CTA for natural flow

## Test plan
- [ ] Open SoW edit form with 2+ milestones
- [ ] Button should appear at the bottom of the milestones list
- [ ] Click to add — new milestone appears above the button