### PR TITLE
fix #121: dashboard notifications refresh without reload

### DIFF
--- a/frontend/src/lib/stores/notifications.ts
+++ b/frontend/src/lib/stores/notifications.ts
@@ -1,0 +1,9 @@
+import { writable } from 'svelte/store';
+
+// Incremented by the layout whenever it detects a new unread notification.
+// Dashboard pages subscribe to this to trigger an immediate notification refresh.
+export const notificationTick = writable(0);
+
+export function triggerNotificationRefresh() {
+	notificationTick.update((n) => n + 1);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
 	import { SITE_NAME } from '$lib/config';
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
+	import { triggerNotificationRefresh } from '$lib/stores/notifications';
 
 	let { children } = $props();
 	let unreadCount = $state(0);
@@ -21,7 +22,12 @@
 			const res = await apiFetch('/api/ui/notifications/count');
 			if (res.ok) {
 				const data = await res.json();
-				unreadCount = data.count ?? 0;
+				const newCount = data.count ?? 0;
+				// If unread count increased, signal dashboard pages to refresh immediately
+				if (newCount > unreadCount) {
+					triggerNotificationRefresh();
+				}
+				unreadCount = newCount;
 			}
 		} catch {
 			// best effort

--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
 	import { SITE_NAME } from '$lib/config';
 	import NotificationBar from '$lib/components/NotificationBar.svelte';
+	import { notificationTick } from '$lib/stores/notifications';
 
 	interface Milestone {
 		id: string;
@@ -50,6 +51,16 @@
 	let error = $state('');
 	let retractingJobId = $state<string | null>(null);
 	let retractError = $state('');
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	let initialized = $state(false);
+
+	// Re-fetch notifications immediately when the layout detects new unread ones
+	$effect(() => {
+		// Subscribe to tick; skip the initial value (0) before data is loaded
+		if ($notificationTick > 0 && initialized) {
+			fetchNotifications();
+		}
+	});
 
 	function statusBadge(status: string): string {
 		const map: Record<string, string> = {
@@ -77,6 +88,22 @@
 
 	function handleDismiss(id: string) {
 		notifications = notifications.filter((n) => n.id !== id);
+	}
+
+	async function fetchNotifications() {
+		try {
+			const res = await apiFetch('/api/ui/notifications');
+			if (res.ok) {
+				const fresh: Notification[] = await res.json();
+				// Preserve locally-dismissed notifications so they don't reappear mid-session
+				const dismissedIds = new Set(
+					notifications.filter((n) => n.dismissed).map((n) => n.id)
+				);
+				notifications = fresh.filter((n) => !dismissedIds.has(n.id));
+			}
+		} catch {
+			// best effort — polling failures are non-fatal
+		}
 	}
 
 	async function retractOffer(jobId: string) {
@@ -120,7 +147,15 @@
 			error = e instanceof Error ? e.message : 'Failed to load jobs';
 		} finally {
 			loading = false;
+			initialized = true;
 		}
+
+		// Poll for new notifications every 30 seconds so the banner appears without a page reload
+		pollInterval = setInterval(fetchNotifications, 30_000);
+	});
+
+	onDestroy(() => {
+		if (pollInterval !== null) clearInterval(pollInterval);
 	});
 </script>
 

--- a/frontend/src/routes/dashboard/manager/+page.svelte
+++ b/frontend/src/routes/dashboard/manager/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { apiFetch, isAuthenticated, auth } from '$lib/stores/auth';
 	import { goto } from '$app/navigation';
 	import { SITE_NAME } from '$lib/config';
 	import NotificationBar from '$lib/components/NotificationBar.svelte';
+	import { notificationTick } from '$lib/stores/notifications';
 
 	interface Agent {
 		id: string;
@@ -48,6 +49,16 @@
 	let notifications: Notification[] = $state([]);
 	let loading = $state(true);
 	let error = $state('');
+	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	let initialized = $state(false);
+
+	// Re-fetch notifications immediately when the layout detects new unread ones
+	$effect(() => {
+		// Subscribe to tick; skip the initial value (0) before data is loaded
+		if ($notificationTick > 0 && initialized) {
+			fetchNotifications();
+		}
+	});
 
 	// Create agent form
 	let showCreateForm = $state(false);
@@ -126,6 +137,22 @@
 		notifications = notifications.filter((n) => n.id !== id);
 	}
 
+	async function fetchNotifications() {
+		try {
+			const res = await apiFetch('/api/ui/notifications');
+			if (res.ok) {
+				const fresh: Notification[] = await res.json();
+				// Preserve locally-dismissed notifications so they don't reappear mid-session
+				const dismissedIds = new Set(
+					notifications.filter((n) => n.dismissed).map((n) => n.id)
+				);
+				notifications = fresh.filter((n) => !dismissedIds.has(n.id));
+			}
+		} catch {
+			// best effort — polling failures are non-fatal
+		}
+	}
+
 	async function loadData() {
 		try {
 			const [agentsRes, jobsRes, notifRes] = await Promise.all([
@@ -155,6 +182,14 @@
 			return;
 		}
 		await loadData();
+		initialized = true;
+
+		// Poll for new notifications every 30 seconds so the banner appears without a page reload
+		pollInterval = setInterval(fetchNotifications, 30_000);
+	});
+
+	onDestroy(() => {
+		if (pollInterval !== null) clearInterval(pollInterval);
 	});
 
 	async function createAgent(e: SubmitEvent) {


### PR DESCRIPTION
## Summary
- New `notificationTick` store acts as signal bus between layout navbar and dashboard pages
- When layout detects new notification (count increased), it signals dashboard pages to refresh immediately
- Dashboard pages also poll every 30 seconds as fallback
- Merges new notifications while preserving locally-dismissed items

## Fixes
Closes #121

## Changes
- New: `frontend/src/lib/stores/notifications.ts` (signal store)
- Updated: `frontend/src/routes/+layout.svelte` (trigger on new notifications)
- Updated: `frontend/src/routes/dashboard/employer/+page.svelte` (reactive refresh)
- Updated: `frontend/src/routes/dashboard/manager/+page.svelte` (reactive refresh)

## Tests
Go build and tests pass.