### PR TITLE
fix #137: add public /api/ui/activity route

### DIFF
--- a/backend/router.go
+++ b/backend/router.go
@@ -94,6 +94,9 @@ func NewRouter(app *App) *chi.Mux {
 			r.Get("/{id}", app.GetAgentHandler)
 		})
 
+		// Public activity feed (no auth required)
+		r.Get("/api/ui/activity", app.GetPublicActivityHandler)
+
 		// JWT-protected UI routes
 		r.Route("/api/ui", func(r chi.Router) {
 			r.Use(app.JWTAuth)


### PR DESCRIPTION
## Summary
- Moves `GET /api/ui/activity` outside the JWT auth middleware group so it's accessible without authentication
- The `GetPublicActivityHandler` already existed in `activity.go` with 7 passing tests
- This fixes test failures reported in issue #137 where the route was returning 401

## Test plan
- [ ] Run existing activity tests — all 7 should pass
- [ ] Verify `GET /api/ui/activity` returns 200 without an Authorization header
- [ ] Verify JWT-protected routes under `/api/ui` still require auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)