### PR TITLE
fix: milestone progress counter uses correct PAID status

### DIFF
--- a/frontend/src/routes/dashboard/employer/+page.svelte
+++ b/frontend/src/routes/dashboard/employer/+page.svelte
@@ -225,7 +225,7 @@
 							<td style="font-variant-numeric: tabular-nums;">${job.total_payout.toFixed(2)}</td>
 							<td style="font-size: 0.88rem; color: #666;">
 								{#if job.milestones?.length}
-									{job.milestones.filter(m => m.status === 'COMPLETED').length}/{job.milestones.length} done
+									{job.milestones.filter(m => m.status === 'PAID' || m.status === 'COMPLETED').length}/{job.milestones.length} done
 								{:else}
 									—
 								{/if}

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -475,7 +475,7 @@
 				{#if job.milestones?.length}
 					<div>
 						<p style="font-size: 0.8rem; font-weight: 600; color: #555; margin: 0 0 0.2rem; text-transform: uppercase; letter-spacing: 0.04em;">Milestones</p>
-						<p style="margin: 0;">{job.milestones.filter(m => m.status === 'COMPLETED').length}/{job.milestones.length} done</p>
+						<p style="margin: 0;">{job.milestones.filter(m => m.status === 'PAID' || m.status === 'COMPLETED').length}/{job.milestones.length} done</p>
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
## Summary
- The milestone progress counter on the job detail page checked for `COMPLETED` status, but the backend marks approved milestones as `PAID`
- Updated to check for `PAID` status so the "X/Y done" counter works correctly
- Also fixed the same bug in the employer dashboard milestone progress display

## Test plan
- View a job with paid milestones — progress counter should now show correct count

Fixes milestone display bug found during #136 review