### PR TITLE
fix #128: prevent premature job completion with milestones

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -746,7 +746,22 @@ func (app *App) ApproveMilestoneHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Check if there is a next PENDING milestone.
+	// Check if there are any remaining unpaid milestones (PENDING or REVIEW_REQUESTED).
+	// We must check for both statuses: PENDING means not yet submitted, REVIEW_REQUESTED
+	// means the agent submitted early (before the previous milestone was approved). In both
+	// cases the job should NOT be marked COMPLETED yet. We pick the next PENDING milestone
+	// (lowest order_index) for the AWAITING_PAYMENT notification; if none are PENDING but
+	// some are REVIEW_REQUESTED the job stays IN_PROGRESS until those are also approved.
+	var remainingCount int
+	if cntErr := app.DB.QueryRow(
+		`SELECT COUNT(*) FROM milestones WHERE sow_id = ? AND status != 'PAID'`,
+		m.SowID,
+	).Scan(&remainingCount); cntErr != nil {
+		log.Error("milestone approval: failed to count remaining milestones", "sow_id", m.SowID, "error", cntErr)
+		// Non-fatal: fall through to the per-status checks below.
+		remainingCount = -1
+	}
+
 	var nextMilestoneID string
 	var nextMilestoneAmount int64
 	var nextMilestoneOrderIndex int
@@ -757,8 +772,12 @@ func (app *App) ApproveMilestoneHandler(w http.ResponseWriter, r *http.Request) 
 		m.SowID,
 	).Scan(&nextMilestoneID, &nextMilestoneAmount, &nextMilestoneOrderIndex)
 
-	if nextMilestoneErr == nil {
-		// There is a next milestone — put job back to AWAITING_PAYMENT.
+	if remainingCount > 0 && nextMilestoneErr == sql.ErrNoRows {
+		// There are remaining milestones but none are PENDING — they are in
+		// REVIEW_REQUESTED. The job stays IN_PROGRESS; nothing to do here.
+		log.Info("milestone approved: remaining milestones are in REVIEW_REQUESTED, job stays IN_PROGRESS", "job_id", jobID)
+	} else if nextMilestoneErr == nil {
+		// There is a next PENDING milestone — put job back to AWAITING_PAYMENT.
 		nextMilestoneNumber := nextMilestoneOrderIndex + 1
 		if _, dbErr := app.DB.Exec(
 			`UPDATE jobs SET status = 'AWAITING_PAYMENT', current_milestone_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?`,
@@ -1175,6 +1194,26 @@ func (app *App) UIDeliverJobHandler(w http.ResponseWriter, r *http.Request) {
 	var req DeliverJobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Block delivery on jobs that have milestones — each milestone must be
+	// submitted individually via the SubmitMilestoneHandler so the employer
+	// can review and approve them one by one. This mirrors the same guard in
+	// DeliverJobHandler (API key path).
+	var milestoneCount int
+	if err := app.DB.QueryRow(
+		`SELECT COUNT(*) FROM milestones m
+		 JOIN sow s ON m.sow_id = s.id
+		 WHERE s.job_id = ?`,
+		jobID,
+	).Scan(&milestoneCount); err != nil {
+		log.Error("ui deliver job: failed to check milestones", "job_id", jobID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+	if milestoneCount > 0 {
+		writeError(w, http.StatusBadRequest, "job has milestones — submit each milestone via POST /milestones/{milestone_id}/submit instead")
 		return
 	}
 

--- a/backend/jobs_test.go
+++ b/backend/jobs_test.go
@@ -781,6 +781,206 @@ func TestDeliverJobNoMilestonesStillWorks(t *testing.T) {
 	}
 }
 
+// TestUIDeliverJobBlockedWhenMilestonesExist verifies that UIDeliverJobHandler (JWT path)
+// also rejects delivery when the job has milestones — matching the same guard in the API
+// key DeliverJobHandler. Regression for issue #128 (bug surviving PRs #140 and #141).
+func TestUIDeliverJobBlockedWhenMilestonesExist(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, managerID, agentID, agentAPIKey := setupJobFixtures(t, app)
+	employerTok := makeAuthToken(t, app, employerID, "EMPLOYER")
+	managerTok := makeAuthToken(t, app, managerID, "AGENT_MANAGER")
+	_ = agentAPIKey
+
+	jobID, _, _ := setupSowWithMilestones(t, app, router, employerID, managerID, agentID, agentAPIKey)
+
+	// Use a 100% coupon to skip Stripe and move job to IN_PROGRESS.
+	if _, err := app.DB.Exec(
+		`INSERT INTO coupons (code, value, max_uses, times_used) VALUES ('UIDEL128', '100%', 10, 0)`,
+	); err != nil {
+		t.Fatalf("insert coupon: %v", err)
+	}
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/checkout",
+		map[string]string{"coupon_code": "UIDEL128"}, employerTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("checkout: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify job is IN_PROGRESS.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status != "IN_PROGRESS" {
+		t.Fatalf("expected IN_PROGRESS, got %q", job.Status)
+	}
+
+	// Attempt to use UIDeliverJobHandler on a job that has milestones — should be rejected.
+	body := DeliverJobRequest{DeliveryNotes: "Done", DeliveryURL: "https://example.com"}
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/deliver", body, managerTok)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("ui deliver with milestones: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Job must still be IN_PROGRESS (not DELIVERED).
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status != "IN_PROGRESS" {
+		t.Errorf("job should still be IN_PROGRESS after rejected ui deliver, got %q", job.Status)
+	}
+}
+
+// TestMilestoneLifecycleThreeMilestones verifies the full 3-milestone flow — the specific
+// scenario reported in issue #128. After approving milestone 1, the job must NOT be
+// marked COMPLETED; it must proceed to AWAITING_PAYMENT for milestone 2, then milestone 3.
+func TestMilestoneLifecycleThreeMilestones(t *testing.T) {
+	t.Parallel()
+	app := setupTestApp(t)
+	router := NewRouter(app)
+
+	employerID, managerID, agentID, agentAPIKey := setupJobFixtures(t, app)
+	employerTok := makeAuthToken(t, app, employerID, "EMPLOYER")
+	managerTok := makeAuthToken(t, app, managerID, "AGENT_MANAGER")
+
+	// Create a job with 3 milestones.
+	hireBody := HireRequest{
+		AgentID:      agentID,
+		Title:        "Three milestone job",
+		TotalPayout:  300,
+		TimelineDays: 21,
+	}
+	rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/hire", hireBody, employerTok)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("hire: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var job Job
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	jobID := job.ID
+
+	// Agent manager accepts.
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/accept", nil, managerTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("accept: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Create SOW with 3 milestones (100 + 100 + 100 = 300).
+	sowBody := SOWRequest{
+		DetailedSpec: "Build three things",
+		WorkProcess:  "Weekly updates",
+		PriceCents:   30000,
+		TimelineDays: 21,
+		Milestones: []SOWMilestoneInput{
+			{Title: "Phase 1", Amount: 100, Deliverables: "First third"},
+			{Title: "Phase 2", Amount: 100, Deliverables: "Second third"},
+			{Title: "Phase 3", Amount: 100, Deliverables: "Final third"},
+		},
+	}
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/sow", sowBody, employerTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("create sow: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Both parties accept SOW.
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/sow/accept", nil, employerTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("employer sow accept: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/sow/accept", nil, managerTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("manager sow accept: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify AWAITING_PAYMENT and 3 milestones.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status != "AWAITING_PAYMENT" {
+		t.Fatalf("expected AWAITING_PAYMENT, got %q", job.Status)
+	}
+	if len(job.Milestones) != 3 {
+		t.Fatalf("expected 3 milestones, got %d", len(job.Milestones))
+	}
+	m1ID := job.Milestones[0].ID
+	m2ID := job.Milestones[1].ID
+	m3ID := job.Milestones[2].ID
+
+	runMilestone := func(mID, couponSuffix string) {
+		t.Helper()
+		couponCode := fmt.Sprintf("MS-%s-%s", mID[:4], couponSuffix)
+		if _, err := app.DB.Exec(
+			`INSERT INTO coupons (code, value, max_uses, times_used) VALUES (?, '100%', 1, 0)`, couponCode,
+		); err != nil {
+			t.Fatalf("insert coupon %s: %v", couponCode, err)
+		}
+		rr := doRequest(t, router, http.MethodPost, "/api/ui/jobs/"+jobID+"/checkout",
+			map[string]string{"coupon_code": couponCode}, employerTok)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("checkout %s: expected 200, got %d: %s", mID, rr.Code, rr.Body.String())
+		}
+
+		// Verify IN_PROGRESS.
+		rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+		json.Unmarshal(rr.Body.Bytes(), &job)
+		if job.Status != "IN_PROGRESS" {
+			t.Fatalf("expected IN_PROGRESS after checkout for %s, got %q", mID, job.Status)
+		}
+
+		// Agent submits milestone.
+		submitBody := SubmitProofRequest{
+			ProofOfWorkURL:   "https://example.com/" + mID,
+			ProofOfWorkNotes: "Done",
+		}
+		rr = doRequest(t, router, http.MethodPost,
+			"/api/v1/jobs/"+jobID+"/milestones/"+mID+"/submit", submitBody, agentAPIKey)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("submit %s: expected 200, got %d: %s", mID, rr.Code, rr.Body.String())
+		}
+
+		// Employer approves milestone.
+		rr = doRequest(t, router, http.MethodPost,
+			"/api/ui/jobs/"+jobID+"/milestones/"+mID+"/approve", nil, employerTok)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("approve %s: expected 200, got %d: %s", mID, rr.Code, rr.Body.String())
+		}
+	}
+
+	// --- Milestone 1 ---
+	runMilestone(m1ID, "1")
+
+	// After M1 approved, job must NOT be COMPLETED — must be AWAITING_PAYMENT.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status == "COMPLETED" {
+		t.Errorf("BUG: job marked COMPLETED after only milestone 1 of 3 was approved")
+	}
+	if job.Status != "AWAITING_PAYMENT" {
+		t.Errorf("expected AWAITING_PAYMENT after m1 approved, got %q", job.Status)
+	}
+
+	// --- Milestone 2 ---
+	runMilestone(m2ID, "2")
+
+	// After M2 approved, job must NOT be COMPLETED — must be AWAITING_PAYMENT.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status == "COMPLETED" {
+		t.Errorf("BUG: job marked COMPLETED after only milestone 2 of 3 was approved")
+	}
+	if job.Status != "AWAITING_PAYMENT" {
+		t.Errorf("expected AWAITING_PAYMENT after m2 approved, got %q", job.Status)
+	}
+
+	// --- Milestone 3 (last) ---
+	runMilestone(m3ID, "3")
+
+	// After M3 (last) approved, job MUST be COMPLETED.
+	rr = doRequest(t, router, http.MethodGet, "/api/ui/jobs/"+jobID, nil, employerTok)
+	json.Unmarshal(rr.Body.Bytes(), &job)
+	if job.Status != "COMPLETED" {
+		t.Errorf("expected COMPLETED after all 3 milestones approved, got %q", job.Status)
+	}
+}
+
 // TestDeclineJobResetsSowAccepted verifies that when an agent declines a job via the
 // agent API key path, both SoW accepted fields are reset to false. This ensures that
 // if the employer re-offers the same job, the new offer starts with a clean acceptance


### PR DESCRIPTION
## Summary
- **UIDeliverJobHandler** now blocks whole-job delivery when milestones exist, forcing per-milestone submission (mirrors the API-key path guard in `DeliverJobHandler`)
- **ApproveMilestoneHandler** now counts all non-PAID milestones before deciding to complete a job, fixing the race condition where `REVIEW_REQUESTED` milestones were ignored

## Root Cause
Two separate paths allowed a multi-milestone job to be marked `COMPLETED` after only the first milestone:
1. The UI deliver endpoint (`/api/ui/jobs/{id}/deliver`) had no milestone guard — it set the job to `DELIVERED` regardless
2. The milestone approval logic only looked for `PENDING` next milestones — if an agent submitted milestones 2 & 3 early (status `REVIEW_REQUESTED`), the query found zero `PENDING` rows and marked the job `COMPLETED`

## Test plan
- [ ] Create a job with 3 milestones
- [ ] Deliver and approve milestone 1 → job should stay `IN_PROGRESS`
- [ ] Deliver and approve milestone 2 → job should stay `IN_PROGRESS`
- [ ] Deliver and approve milestone 3 → job should become `COMPLETED`
- [ ] Try to deliver the whole job via UI when milestones exist → should get HTTP 400
- [ ] New unit tests: `TestUIDeliverJobBlockedWhenMilestonesExist`, `TestMilestoneLifecycleThreeMilestones`

🤖 Generated with [Claude Code](https://claude.com/claude-code)