### PR TITLE
fix #143: add milestone submit/approve UI for dashboard

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -1067,6 +1067,96 @@ func (app *App) SubmitMilestoneHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(m)
 }
 
+// UISubmitMilestoneHandler allows an AGENT_MANAGER to submit a milestone for review via the UI (JWT auth).
+// This mirrors SubmitMilestoneHandler (which uses API key auth) but is called from the web frontend.
+// POST /api/ui/jobs/{job_id}/milestones/{milestone_id}/submit
+func (app *App) UISubmitMilestoneHandler(w http.ResponseWriter, r *http.Request) {
+	log := slog.With("request_id", requestID(r.Context()), "handler", "ui_submit_milestone")
+
+	role, _ := r.Context().Value(contextKeyUserRole).(string)
+	if role != "AGENT_MANAGER" {
+		log.Warn("authz failure: submit milestone requires AGENT_MANAGER role", "role", role)
+		writeError(w, http.StatusForbidden, "only AGENT_MANAGER role can submit milestones")
+		return
+	}
+
+	managerID, _ := r.Context().Value(contextKeyUserID).(string)
+	jobID := chi.URLParam(r, "job_id")
+	milestoneID := chi.URLParam(r, "milestone_id")
+
+	// Verify the job belongs to one of this manager's agents and is in progress.
+	var agentID string
+	err := app.DB.QueryRow(
+		`SELECT j.agent_id FROM jobs j
+		   JOIN agents a ON j.agent_id = a.id
+		  WHERE j.id = ? AND a.manager_id = ? AND j.status = 'IN_PROGRESS'`,
+		jobID, managerID,
+	).Scan(&agentID)
+	if err == sql.ErrNoRows {
+		writeError(w, http.StatusNotFound, "job not found or not in IN_PROGRESS status")
+		return
+	}
+	if err != nil {
+		log.Error("ui submit milestone: db error", "job_id", jobID, "manager_id", managerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	var req SubmitProofRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	result, err := app.DB.Exec(
+		`UPDATE milestones SET status = 'REVIEW_REQUESTED', proof_of_work_url = ?, proof_of_work_notes = ?, updated_at = CURRENT_TIMESTAMP
+		 WHERE id = ? AND sow_id = (SELECT id FROM sow WHERE job_id = ?) AND status = 'PENDING'`,
+		req.ProofOfWorkURL, req.ProofOfWorkNotes, milestoneID, jobID,
+	)
+	if err != nil {
+		log.Error("ui submit milestone: database error", "job_id", jobID, "milestone_id", milestoneID, "manager_id", managerID, "error", err)
+		writeError(w, http.StatusInternalServerError, "database error")
+		return
+	}
+
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		writeError(w, http.StatusBadRequest, "milestone not found or not in PENDING status")
+		return
+	}
+
+	log.Info("milestone submitted for review via UI",
+		"job_id", jobID,
+		"milestone_id", milestoneID,
+		"manager_id", managerID,
+		"proof_url", req.ProofOfWorkURL,
+	)
+
+	var m Milestone
+	row := app.DB.QueryRow(
+		`SELECT id, sow_id, title, amount, order_index, deliverables, status, proof_of_work_url, proof_of_work_notes, created_at, updated_at
+		 FROM milestones WHERE id = ?`,
+		milestoneID,
+	)
+	if err := row.Scan(&m.ID, &m.SowID, &m.Title, &m.Amount, &m.OrderIndex, &m.Deliverables, &m.Status,
+		&m.ProofOfWorkURL, &m.ProofOfWorkNotes, sqliteTime{&m.CreatedAt}, sqliteTime{&m.UpdatedAt}); err != nil {
+		log.Error("ui submit milestone: failed to retrieve after update", "milestone_id", milestoneID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve milestone")
+		return
+	}
+
+	// Notify employer that a milestone was delivered
+	var employerID string
+	if err := app.DB.QueryRow("SELECT employer_id FROM jobs WHERE id = ?", jobID).Scan(&employerID); err == nil {
+		_ = app.CreateNotification(employerID, jobID, NotifMilestoneDelivered,
+			"Milestone submitted: "+m.Title,
+			"An agent has submitted a milestone for your review.")
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(m)
+}
+
 // --- Delivery and Approval Handlers ---
 
 type DeliverJobRequest struct {

--- a/backend/router.go
+++ b/backend/router.go
@@ -125,6 +125,7 @@ func NewRouter(app *App) *chi.Mux {
 				r.Put("/{job_id}/milestones/{milestone_id}", app.EditMilestoneHandler)
 				r.Delete("/{job_id}/milestones/{milestone_id}", app.DeleteMilestoneHandler)
 				r.Post("/{job_id}/milestones/{milestone_id}/approve", app.ApproveMilestoneHandler)
+			r.Post("/{job_id}/milestones/{milestone_id}/submit", app.UISubmitMilestoneHandler)
 				r.Post("/{job_id}/sow", app.CreateOrUpdateSOW)
 				r.Get("/{job_id}/sow", app.GetSOW)
 				r.Post("/{job_id}/sow/accept", app.AcceptSOW)

--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -55,6 +55,8 @@
 		status: string;
 		submitted_at: string;
 		approved_at: string;
+		proof_of_work_url: string;
+		proof_of_work_notes: string;
 	}
 
 	interface Job {
@@ -99,6 +101,11 @@
 	let rejectError = $state('');
 	let rejectReason = $state('');
 	let showRejectForm = $state(false);
+	let milestoneSubmitId: string | null = $state(null);
+	let milestoneProofUrl = $state('');
+	let milestoneProofNotes = $state('');
+	let milestoneSubmitting = $state(false);
+	let milestoneSubmitError = $state('');
 
 	const isEmployer = $derived($auth?.role === 'EMPLOYER');
 	const isManager = $derived($auth?.role === 'AGENT_MANAGER');
@@ -337,6 +344,51 @@
 			rejectError = e instanceof Error ? e.message : 'Failed to reject offer';
 		} finally {
 			rejectLoading = false;
+		}
+	}
+
+	async function submitMilestone() {
+		if (!milestoneSubmitId || !job) return;
+		milestoneSubmitting = true;
+		milestoneSubmitError = '';
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${job.id}/milestones/${milestoneSubmitId}/submit`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					proof_of_work_url: milestoneProofUrl,
+					proof_of_work_notes: milestoneProofNotes
+				})
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to submit milestone' }));
+				throw new Error(err.error || 'Failed to submit milestone');
+			}
+			milestoneSubmitId = null;
+			milestoneProofUrl = '';
+			milestoneProofNotes = '';
+			await loadJob();
+		} catch (e: unknown) {
+			milestoneSubmitError = e instanceof Error ? e.message : 'Failed to submit milestone';
+		} finally {
+			milestoneSubmitting = false;
+		}
+	}
+
+	async function approveMilestone(milestoneId: string) {
+		if (!job) return;
+		try {
+			const res = await apiFetch(`/api/ui/jobs/${job.id}/milestones/${milestoneId}/approve`, {
+				method: 'POST'
+			});
+			if (!res.ok) {
+				const err = await res.json().catch(() => ({ error: 'Failed to approve milestone' }));
+				throw new Error(err.error || 'Failed to approve milestone');
+			}
+			await loadJob();
+		} catch (e: unknown) {
+			// ignore silently — could surface an error state if needed
+			console.error(e);
 		}
 	}
 
@@ -738,8 +790,8 @@
 			</div>
 		{/if}
 
-		<!-- Delivery section — shown from IN_PROGRESS onward -->
-		{#if ['IN_PROGRESS', 'DELIVERED', 'COMPLETED'].includes(job.status)}
+		<!-- Delivery section — shown from IN_PROGRESS onward (not for milestone jobs) -->
+		{#if ['IN_PROGRESS', 'DELIVERED', 'COMPLETED'].includes(job.status) && !job.milestones?.length}
 			<DeliverySection
 				{jobId}
 				jobStatus={job.status}
@@ -770,6 +822,92 @@
 										<li style="margin-bottom: 0.2rem;">{criterion.description}</li>
 									{/each}
 								</ul>
+							{/if}
+
+							<!-- Milestone submit form (manager, PENDING, job IN_PROGRESS) -->
+							{#if milestone.status === 'PENDING' && isManager && job.status === 'IN_PROGRESS'}
+								{#if milestoneSubmitId === milestone.id}
+									<div style="margin-top: 0.75rem; padding: 0.75rem; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px;">
+										{#if milestoneSubmitError}
+											<div class="alert alert-error" style="margin-bottom: 0.5rem;">{milestoneSubmitError}</div>
+										{/if}
+										<div class="form-group" style="margin-bottom: 0.5rem;">
+											<label style="font-size: 0.85rem; font-weight: 600; color: #555;">Proof of Work Notes</label>
+											<textarea
+												bind:value={milestoneProofNotes}
+												placeholder="Describe what was completed for this milestone…"
+												style="min-height: 70px; margin-top: 0.3rem;"
+												disabled={milestoneSubmitting}
+											></textarea>
+										</div>
+										<div class="form-group" style="margin-bottom: 0.75rem;">
+											<label style="font-size: 0.85rem; font-weight: 600; color: #555;">Proof of Work URL (optional)</label>
+											<input
+												type="url"
+												bind:value={milestoneProofUrl}
+												placeholder="https://…"
+												style="margin-top: 0.3rem;"
+												disabled={milestoneSubmitting}
+											/>
+										</div>
+										<div style="display: flex; gap: 0.5rem;">
+											<button
+												type="button"
+												class="btn btn-primary"
+												style="font-size: 0.85rem;"
+												onclick={submitMilestone}
+												disabled={milestoneSubmitting}
+											>
+												{milestoneSubmitting ? 'Submitting…' : 'Submit for Review'}
+											</button>
+											<button
+												type="button"
+												class="btn btn-secondary"
+												style="font-size: 0.85rem;"
+												onclick={() => { milestoneSubmitId = null; milestoneProofUrl = ''; milestoneProofNotes = ''; milestoneSubmitError = ''; }}
+												disabled={milestoneSubmitting}
+											>
+												Cancel
+											</button>
+										</div>
+									</div>
+								{:else}
+									<button
+										type="button"
+										class="btn btn-secondary"
+										style="margin-top: 0.5rem; font-size: 0.85rem;"
+										onclick={() => { milestoneSubmitId = milestone.id; milestoneSubmitError = ''; }}
+									>
+										Submit Milestone
+									</button>
+								{/if}
+							{/if}
+
+							<!-- Review requested: show proof details + approve button -->
+							{#if milestone.status === 'REVIEW_REQUESTED'}
+								<div style="margin-top: 0.5rem; font-size: 0.88rem; color: #555;">
+									{#if milestone.proof_of_work_notes}
+										<p style="margin: 0 0 0.3rem;"><strong>Proof notes:</strong> {milestone.proof_of_work_notes}</p>
+									{/if}
+									{#if milestone.proof_of_work_url}
+										<p style="margin: 0 0 0.3rem;"><strong>Proof URL:</strong> <a href={milestone.proof_of_work_url} target="_blank" rel="noopener noreferrer" style="color: #4f46e5;">{milestone.proof_of_work_url}</a></p>
+									{/if}
+								</div>
+								{#if isEmployer}
+									<button
+										type="button"
+										class="btn btn-primary"
+										style="margin-top: 0.5rem; font-size: 0.85rem;"
+										onclick={() => approveMilestone(milestone.id)}
+									>
+										Approve Milestone
+									</button>
+								{/if}
+							{/if}
+
+							<!-- Approved/Paid: show checkmark -->
+							{#if milestone.status === 'APPROVED' || milestone.status === 'PAID'}
+								<p style="margin: 0.4rem 0 0; font-size: 0.88rem; color: #065f46;">&#10003; {milestoneProgressLabel(milestone.status)}</p>
 							{/if}
 						</div>
 					{/each}


### PR DESCRIPTION
## Summary
- Adds `POST /api/ui/jobs/{job_id}/milestones/{milestone_id}/submit` endpoint so agent managers can submit milestone deliveries from the web dashboard (previously only available via API key)
- Adds per-milestone submit form (proof URL + notes) and approve button in the milestone progress card
- Shows submitted proof-of-work details for milestones in REVIEW_REQUESTED status
- Hides the job-level DeliverySection when a job has milestones, preventing the confusing "job has milestones" error

## Test plan
- [ ] Create a 3-milestone job, fund it, and verify the milestone progress card shows "Submit Milestone" buttons for the agent manager
- [ ] Submit milestone 1 with proof URL and notes — verify status changes to REVIEW_REQUESTED
- [ ] As employer, verify "Approve Milestone" button appears and works
- [ ] Verify job-level delivery form is hidden for milestone jobs
- [ ] Verify non-milestone jobs still show the normal DeliverySection

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)