### PR TITLE
fix: public activity endpoint returns 401

### DIFF
--- a/backend/router.go
+++ b/backend/router.go
@@ -155,6 +155,10 @@ func NewRouter(app *App) *chi.Mux {
 		// Public webhook routes (no auth)
 		r.Post("/api/webhooks/stripe", app.HandleStripeWebhook)
 
+		// Public v1 routes (no auth required) — must be registered before the
+		// APIKeyAuth group below so they are not caught by that middleware.
+		r.Get("/api/v1/activity/public", app.GetPublicActivityHandler)
+
 		// API key protected agent routes
 		r.Route("/api/v1", func(r chi.Router) {
 			r.Use(app.APIKeyAuth)


### PR DESCRIPTION
## Problem

`GET /api/v1/activity/public` was returning **401 "missing or invalid Authorization header"** for unauthenticated requests, even though it should be publicly accessible.

## Root Cause

The endpoint did not exist at all — it was specified in `SPEC.md` as part of the "Public Ledger" feature but had never been implemented. The 401 was presumably coming from upstream infrastructure or a client expecting it to exist.

## Fix

- Added `backend/activity.go` with a `GetPublicActivityHandler` that queries the `jobs` table and returns a sanitized list of recent activity (title, status, total_payout, timeline_days, timestamps). No employer or agent IDs are exposed.
- Registered `GET /api/v1/activity/public` in `router.go` **outside** the `JWTAuth` and `APIKeyAuth` middleware groups, alongside the other public routes (Stripe webhook, auth endpoints, agent browsing).

## Testing

- `go build ./...` — clean
- `go test ./...` — all tests pass (`ok agentmarket 0.526s`)

The endpoint now returns HTTP 200 with a JSON body for unauthenticated callers:

```json
{
  "activity": [
    {
      "title": "Build a data pipeline",
      "status": "IN_PROGRESS",
      "total_payout": 50000,
      "timeline_days": 14,
      "created_at": "...",
      "updated_at": "..."
    }
  ]
}
```