### PR TITLE
fix: SOW payment button uses correct checkout URL field

### DIFF
--- a/frontend/src/lib/components/SOW.svelte
+++ b/frontend/src/lib/components/SOW.svelte
@@ -316,8 +316,8 @@
 				throw new Error(err.error || 'Failed to initiate checkout');
 			}
 			const data = await res.json();
-			if (data.checkout_url) {
-				window.location.href = data.checkout_url;
+			if (data.url) {
+				window.location.href = data.url;
 			} else {
 				throw new Error('No checkout URL returned');
 			}


### PR DESCRIPTION
proceedToPayment() in SOW.svelte checked data.checkout_url but backend returns data.url. Fixed to match the backend response format.