### PR TITLE
fix: show payment amount in fallback display

### DIFF
--- a/frontend/src/routes/jobs/[job_id]/+page.svelte
+++ b/frontend/src/routes/jobs/[job_id]/+page.svelte
@@ -660,7 +660,11 @@
 					</p>
 				{:else}
 					<p style="margin: 0 0 0.5rem; color: #666; font-size: 0.9rem;">
-						Both parties have agreed to the SoW. Complete payment to start the job.
+						Both parties have agreed to the SoW. Complete payment
+						{#if currentPaymentAmountCents > 0}
+							of <strong>${(currentPaymentAmountCents / 100).toFixed(2)}</strong>
+						{/if}
+						to start the job.
 					</p>
 				{/if}
 
@@ -753,7 +757,9 @@
 							{@const totalDisplay = baseDisplay + tipCents() / 100}
 							Authorize Milestone {currentPaymentMilestoneNumber} (${totalDisplay.toFixed(2)})
 						{:else}
-							Pay Now{tipCents() > 0 ? ` (+$${(tipCents() / 100).toFixed(2)} tip)` : ''}
+							{@const baseAmt = couponApplied ? couponFinalCents / 100 : currentPaymentAmountCents / 100}
+							{@const totalAmt = baseAmt + tipCents() / 100}
+							Pay Now (${totalAmt.toFixed(2)}){tipCents() > 0 ? ` incl. $${(tipCents() / 100).toFixed(2)} tip` : ''}
 						{/if}
 					{/snippet}
 					<button class="btn btn-primary" onclick={handleCheckout} disabled={checkoutLoading}>


### PR DESCRIPTION
## Summary
- When milestones exist but none are in PENDING status (e.g. after manual job/milestone reset), the payment form falls through to the no-milestone path
- Previously this showed "Complete payment to start the job" with no amount — now it displays the computed charge amount
- Pay Now button also now shows the total (with coupon/tip adjustments)

## Root cause
`getFirstPendingMilestone()` returns null when no milestone has `status === 'PENDING'`, causing the fallback to `sow.price_cents` (full SoW amount) with no price shown in the UI text.

## Test plan
- [ ] Reset a job to AWAITING_PAYMENT with milestones in non-PENDING status → verify price shows in fallback text
- [ ] Normal flow with PENDING milestones → verify milestone-specific display still works
- [ ] Verify Pay Now button shows correct amount in both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)